### PR TITLE
everything

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/coverage/
+/node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+Note: __README.md__ is generated from comments in __index.js__. Do not modify
+__README.md__ directly.
+
+1.  Update local master branch:
+
+        $ git checkout master
+        $ git pull upstream master
+
+2.  Create feature branch:
+
+        $ git checkout -b feature-x
+
+3.  Make one or more atomic commits, and ensure that each commit has a
+    descriptive commit message. Commit messages should be line wrapped
+    at 72 characters.
+
+4.  Run `make lint test`, and address any errors. Preferably, fix commits
+    in place using `git rebase` or `git commit --amend` to make the changes
+    easier to review.
+
+5.  Push:
+
+        $ git push origin feature-x
+
+6.  Open a pull request.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Sanctuary
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,81 @@
+DOCTEST = node_modules/.bin/doctest --nodejs '--harmony' --module commonjs --prefix .
+ESLINT = node_modules/.bin/eslint --config node_modules/sanctuary-style/eslint-es3.json --env es3
+ISTANBUL = node_modules/.bin/istanbul
+NPM = npm
+PREDOCTEST = scripts/predoctest
+TRANSCRIBE = node_modules/.bin/transcribe
+XYZ = node_modules/.bin/xyz --repo git@github.com:sanctuary-js/sanctuary-type-classes.git --script scripts/prepublish
+
+TEST = $(shell find test -name '*.js' | sort)
+
+
+.PHONY: all
+all: LICENSE README.md
+
+.PHONY: LICENSE
+LICENSE:
+	cp -- '$@' '$@.orig'
+	sed 's/Copyright (c) .* Sanctuary/Copyright (c) $(shell git log --date=format:%Y --pretty=format:%ad | sort -r | head -n 1) Sanctuary/' '$@.orig' >'$@'
+	rm -- '$@.orig'
+
+README.md: index.js.tmp
+	$(TRANSCRIBE) \
+	  --heading-level 4 \
+	  --url 'https://github.com/sanctuary-js/sanctuary-type-classes/blob/v$(VERSION)/index.js#L{line}' \
+	  -- '$<' \
+	| LC_ALL=C sed 's/<h4 name="\(.*\)#\(.*\)">\(.*\)\1#\2/<h4 name="\1.prototype.\2">\3\1#\2/' >'$@'
+
+.INTERMEDIATE: index.js.tmp
+index.js.tmp: index.js
+	sed -e '/^[/][/]:/ s,\([[:<:]][[:alnum:]]*\),<a href="#\1">\1</a>,g' -e 's,^//:,//.,' '$<' >'$@'
+
+
+.PHONY: doctest
+doctest: index-no-blockquotes.js
+ifeq ($(shell node --version | cut -d . -f 1),v6)
+	$(DOCTEST) -- $^
+else
+	@echo '[WARN] Doctests are only run in Node v6.x.x (current version is $(shell node --version))' >&2
+endif
+
+.INTERMEDIATE: index-no-blockquotes.js
+index-no-blockquotes.js: index.js $(PREDOCTEST)
+	$(PREDOCTEST) '$<' >'$@'
+
+
+.PHONY: lint
+lint:
+	$(ESLINT) \
+	  --global define \
+	  --global module \
+	  --global self \
+	  --rule 'max-len: [error, {code: 79, ignoreUrls: true, ignorePattern: "^ *//(# |  .* :: |[.] > )"}]' \
+	  --rule 'spaced-comment: [error, always, {line: {exceptions: ["."], markers: ["#", ".", ":"]}}]' \
+	  -- index.js
+	$(ESLINT) \
+	  --env node \
+	  -- $(PREDOCTEST) $(TEST)
+	@echo 'Checking for missing link definitions...'
+	grep -o '\[[^]]*\]\[[^]]*\]' index.js \
+	| sort -u \
+	| sed -e 's:\[\(.*\)\]\[\]:\1:' \
+	      -e 's:\[.*\]\[\(.*\)\]:\1:' \
+	      -e '/0-9/d' \
+	| xargs -I '{}' sh -c "grep '^//[.] \[{}\]: ' index.js"
+
+
+.PHONY: release-major release-minor release-patch
+release-major release-minor release-patch:
+	@$(XYZ) --increment $(@:release-%=%)
+
+
+.PHONY: setup
+setup:
+	$(NPM) install
+
+
+.PHONY: test
+test:
+	$(ISTANBUL) cover node_modules/.bin/_mocha -- --timeout 10000 --ui tdd -- test/index.js
+	$(ISTANBUL) check-coverage --branches 100
+	make doctest

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,35 @@
+{
+  "name": "sanctuary-type-classes",
+  "description": "Standard library for Fantasy Land",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/sanctuary-js/sanctuary-type-classes.git"
+  },
+  "main": "index.js",
+  "moduleType": [
+    "amd",
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "algebraic",
+    "functional",
+    "sanctuary",
+    "types"
+  ],
+  "dependencies": {},
+  "ignore": [
+    "/.git/",
+    "/bower_components/",
+    "/coverage/",
+    "/node_modules/",
+    "/scripts/",
+    "/test/",
+    "/.*",
+    "/CONTRIBUTING.md",
+    "/Makefile",
+    "/circle.yml",
+    "/package.json"
+  ]
+}

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,16 @@
+dependencies:
+  override:
+    - printf '%s\n' color=false progress=false >.npmrc
+    - rm -rf node_modules
+    - case $CIRCLE_NODE_INDEX in 0) make setup ;; 1) nvm exec 0.12.7 make setup ;; 2) nvm exec 4 make setup ;; 3) nvm install 6 && nvm exec 6 make setup ;; esac:
+        parallel: true
+
+machine:
+  node:
+    version: 0.10.34
+
+test:
+  override:
+    - make lint
+    - case $CIRCLE_NODE_INDEX in 0) make test ;; 1) nvm exec 0.12.7 make test ;; 2) nvm exec 4 make test ;; 3) nvm exec 6 make test ;; esac:
+        parallel: true

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1299 @@
+/*
+             ############                  #
+            ############                  ###
+                  #####                  #####
+                #####      ####################
+              #####       ######################
+            #####                     ###########
+          #####         ######################
+        #####          ####################
+      #####                        #####
+     ############                 ###
+    ############                 */
+
+//. # sanctuary-type-classes
+//.
+//. The [Fantasy Land Specification][FL] "specifies interoperability of common
+//. algebraic structures" by defining a number of type classes. For each type
+//. class, it states laws which every member of a type must obey in order for
+//. the type to be a member of the type class. In order for the Maybe type to
+//. be considered a [Functor][], for example, every `Maybe a` value must have
+//. a `fantasy-land/map` method which obeys the identity and composition laws.
+//.
+//. This project provides:
+//.
+//.   - [`TypeClass`](#TypeClass), a function for defining type classes;
+//.   - one `TypeClass` value for each Fantasy Land type class;
+//.   - lawful Fantasy Land methods for JavaScript's built-in types;
+//.   - one function for each Fantasy Land method; and
+//.   - several functions derived from these functions.
+//.
+//. ## Type-class hierarchy
+//.
+//. <pre>
+//:  Setoid   Semigroup   Foldable           Functor            Extend
+//: (equals)   (concat)   (reduce)            (map)            (extend)
+//:               |           \             / | | | \             /
+//:               |            \           /  | | |  \           /
+//:               |             \         /   | | |   \         /
+//:               |              \       /    | | |    \       /
+//:               |               \     /     | | |     \     /
+//:               |                \   /      | | |      \   /
+//:               |                 \ /       / | \       \ /
+//:            Monoid           Traversable  /  |  \    Comonad
+//:            (empty)          (traverse)  /   |   \  (extract)
+//:                                        /    |    \
+//:                               Bifunctor   Apply   Profunctor
+//:                                (bimap)     (ap)    (promap)
+//:                                            / \
+//:                                           /   \
+//:                                          /     \
+//:                                         /       \
+//:                                        /         \
+//:                                  Applicative    Chain
+//:                                      (of)      (chain)
+//:                                        \         / \
+//:                                         \       /   \
+//:                                          \     /     \
+//:                                           \   /       \
+//:                                            \ /         \
+//:                                           Monad     ChainRec
+//:                                                    (chainRec)
+//. </pre>
+//.
+//. ## API
+
+(function(f) {
+
+  'use strict';
+
+  /* istanbul ignore else */
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = f();
+  } else if (typeof define === 'function' && define.amd != null) {
+    define([], f);
+  } else {
+    self.sanctuaryTypeClasses = f();
+  }
+
+}(function() {
+
+  'use strict';
+
+  //  has :: (String, Object) -> Boolean
+  var has = function(k, o) {
+    return Object.prototype.hasOwnProperty.call(o, k);
+  };
+
+  //  identity :: a -> a
+  var identity = function(x) { return x; };
+
+  //  prepend :: a -> Array a -> Array a
+  var prepend = function(x) {
+    return function(xs) {
+      return [x].concat(xs);
+    };
+  };
+
+  //  type :: Any -> String
+  var type = function type(x) {
+    return x != null && type(x['@@type']) === 'String' ?
+      x['@@type'] :
+      Object.prototype.toString.call(x).slice('[object '.length, -']'.length);
+  };
+
+  //# TypeClass :: (String, Array TypeClass, a -> Boolean) -> TypeClass
+  //.
+  //. The arguments are:
+  //.
+  //.   - the name of the type class, prefixed by its npm package name;
+  //.   - an array of dependencies; and
+  //.   - a predicate which accepts any JavaScript value and returns `true`
+  //.     if the value satisfies the requirements of the type class; `false`
+  //.     otherwise.
+  //.
+  //. Example:
+  //.
+  //. ```javascript
+  //. //    hasMethod :: String -> a -> Boolean
+  //. const hasMethod = name => x => x != null && typeof x[name] == 'function';
+  //.
+  //. //    Foo :: TypeClass
+  //. const Foo = Z.TypeClass('my-package/Foo', [], hasMethod('foo'));
+  //.
+  //. //    Bar :: TypeClass
+  //. const Bar = Z.TypeClass('my-package/Bar', [Foo], hasMethod('bar'));
+  //. ```
+  //.
+  //. Types whose values have a `foo` method are members of the Foo type class.
+  //. Members of the Foo type class whose values have a `bar` method are also
+  //. members of the Bar type class.
+  //.
+  //. Each `TypeClass` value has a `test` field: a function which accepts
+  //. any JavaScript value and returns `true` if the value satisfies the
+  //. type class's predicate and the predicates of all the type class's
+  //. dependencies; `false` otherwise.
+  //.
+  //. `TypeClass` values may be used with [sanctuary-def][type-classes]
+  //. to define parametrically polymorphic functions which verify their
+  //. type-class constraints at run time.
+  var TypeClass = function(name, dependencies, test) {
+    return {
+      '@@type': 'sanctuary-type-classes/TypeClass',
+      name: name,
+      test: function(x) {
+        return dependencies.every(function(d) { return d.test(x); }) &&
+               test(x);
+      }
+    };
+  };
+
+  //  orConstructor :: (String, Object) -> Function?
+  var orConstructor = function(methodName, x) {
+    return typeof x[methodName] === 'function' ? x : x.constructor;
+  };
+
+  //  data Location = Constructor | Value
+
+  //  Constructor :: Location
+  var Constructor = 'Constructor';
+
+  //  Value :: Location
+  var Value = 'Value';
+
+  //  _funcPath :: (Boolean, Array String, a) -> Nullable Function
+  var _funcPath = function(allowInheritedProps, path, _x) {
+    var x = _x;
+    for (var idx = 0; idx < path.length; idx += 1) {
+      var k = path[idx];
+      if (x == null || !(allowInheritedProps || has(k, x))) return null;
+      x = x[k];
+    }
+    return typeof x === 'function' ? x : null;
+  };
+
+  //  funcPath :: (Array String, a) -> Nullable Function
+  var funcPath = function(path, x) {
+    return _funcPath(true, path, x);
+  };
+
+  //  implPath :: Array String -> Nullable Function
+  var implPath = function(path) {
+    return _funcPath(false, path, implementations);
+  };
+
+  //  $ :: (String, Array TypeClass, StrMap (Array Location)) -> TypeClass
+  var $ = function(_name, dependencies, requirements) {
+    var getBoundMethod = function(_name) {
+      return function(x) {
+        var name = 'fantasy-land/' + _name;
+        var locations = requirements[_name];
+        for (var idx = 0; idx < locations.length; idx += 1) {
+          if (locations[idx] === Constructor) {
+            var f = funcPath(['constructor', name], x) ||
+                    implPath([type(x), name]);
+            /* istanbul ignore else */  // Constructor always listed last
+            if (f) return f;
+          } else {
+            var m = funcPath([name], x) ||
+                    implPath([type(x), 'prototype', name]);
+            if (m) return m.bind(x);
+          }
+        }
+      };
+    };
+
+    var name = 'sanctuary-type-classes/' + _name;
+    var keys = Object.keys(requirements);
+
+    var typeClass = TypeClass(name, dependencies, function(x) {
+      return keys.every(function(_name) {
+        return getBoundMethod(_name)(x) != null;
+      });
+    });
+
+    typeClass.functions = {};
+    keys.forEach(function(_name) {
+      var name = 'fantasy-land/' + _name;
+      if (requirements[_name].indexOf(Constructor) >= 0) {
+        typeClass.functions[_name] = function(typeRep) {
+          var m = /function (\w*)/.exec(typeRep);
+          return m && implPath([m[1], name]) || typeRep[name];
+        };
+      }
+    });
+
+    typeClass.methods = {};
+    keys.forEach(function(_name) {
+      /* istanbul ignore else */  // Value always listed
+      if (requirements[_name].indexOf(Value) >= 0) {
+        typeClass.methods[_name] = getBoundMethod(_name);
+      }
+    });
+
+    return typeClass;
+  };
+
+  //# Setoid :: TypeClass
+  //.
+  //. `TypeClass` value for [Setoid][].
+  //.
+  //. ```javascript
+  //. > Setoid.test(null)
+  //. true
+  //. ```
+  var Setoid = $('Setoid', [], {equals: [Value]});
+
+  //# Semigroup :: TypeClass
+  //.
+  //. `TypeClass` value for [Semigroup][].
+  //.
+  //. ```javascript
+  //. > Semigroup.test('')
+  //. true
+  //.
+  //. > Semigroup.test(0)
+  //. false
+  //. ```
+  var Semigroup = $('Semigroup', [], {concat: [Value]});
+
+  //# Monoid :: TypeClass
+  //.
+  //. `TypeClass` value for [Monoid][].
+  //.
+  //. ```javascript
+  //. > Monoid.test('')
+  //. true
+  //.
+  //. > Monoid.test(0)
+  //. false
+  //. ```
+  var Monoid = $('Monoid', [Semigroup], {empty: [Value, Constructor]});
+
+  //# Functor :: TypeClass
+  //.
+  //. `TypeClass` value for [Functor][].
+  //.
+  //. ```javascript
+  //. > Functor.test([])
+  //. true
+  //.
+  //. > Functor.test('')
+  //. false
+  //. ```
+  var Functor = $('Functor', [], {map: [Value]});
+
+  //# Bifunctor :: TypeClass
+  //.
+  //. `TypeClass` value for [Bifunctor][].
+  //.
+  //. ```javascript
+  //. > Bifunctor.test(Tuple('foo', 64))
+  //. true
+  //.
+  //. > Bifunctor.test([])
+  //. false
+  //. ```
+  var Bifunctor = $('Bifunctor', [Functor], {bimap: [Value]});
+
+  //# Profunctor :: TypeClass
+  //.
+  //. `TypeClass` value for [Profunctor][].
+  //.
+  //. ```javascript
+  //. > Profunctor.test(Math.sqrt)
+  //. true
+  //.
+  //. > Profunctor.test([])
+  //. false
+  //. ```
+  var Profunctor = $('Profunctor', [Functor], {promap: [Value]});
+
+  //# Apply :: TypeClass
+  //.
+  //. `TypeClass` value for [Apply][].
+  //.
+  //. ```javascript
+  //. > Apply.test([])
+  //. true
+  //.
+  //. > Apply.test({})
+  //. false
+  //. ```
+  var Apply = $('Apply', [Functor], {ap: [Value]});
+
+  //# Applicative :: TypeClass
+  //.
+  //. `TypeClass` value for [Applicative][].
+  //.
+  //. ```javascript
+  //. > Applicative.test([])
+  //. true
+  //.
+  //. > Applicative.test({})
+  //. false
+  //. ```
+  var Applicative = $('Applicative', [Apply], {of: [Value, Constructor]});
+
+  //# Chain :: TypeClass
+  //.
+  //. `TypeClass` value for [Chain][].
+  //.
+  //. ```javascript
+  //. > Chain.test([])
+  //. true
+  //.
+  //. > Chain.test({})
+  //. false
+  //. ```
+  var Chain = $('Chain', [Apply], {chain: [Value]});
+
+  //# ChainRec :: TypeClass
+  //.
+  //. `TypeClass` value for [ChainRec][].
+  //.
+  //. ```javascript
+  //. > ChainRec.test([])
+  //. true
+  //.
+  //. > ChainRec.test({})
+  //. false
+  //. ```
+  var ChainRec = $('ChainRec', [Chain], {chainRec: [Value, Constructor]});
+
+  //# Monad :: TypeClass
+  //.
+  //. `TypeClass` value for [Monad][].
+  //.
+  //. ```javascript
+  //. > Monad.test([])
+  //. true
+  //.
+  //. > Monad.test({})
+  //. false
+  //. ```
+  var Monad = $('Monad', [Applicative, Chain], {});
+
+  //# Foldable :: TypeClass
+  //.
+  //. `TypeClass` value for [Foldable][].
+  //.
+  //. ```javascript
+  //. > Foldable.test({})
+  //. true
+  //.
+  //. > Foldable.test('')
+  //. false
+  //. ```
+  var Foldable = $('Foldable', [], {reduce: [Value]});
+
+  //# Traversable :: TypeClass
+  //.
+  //. `TypeClass` value for [Traversable][].
+  //.
+  //. ```javascript
+  //. > Traversable.test([])
+  //. true
+  //.
+  //. > Traversable.test({})
+  //. false
+  //. ```
+  var Traversable = $('Traversable', [Functor, Foldable], {traverse: [Value]});
+
+  //# Extend :: TypeClass
+  //.
+  //. `TypeClass` value for [Extend][].
+  //.
+  //. ```javascript
+  //. > Extend.test([])
+  //. true
+  //.
+  //. > Extend.test({})
+  //. false
+  //. ```
+  var Extend = $('Extend', [], {extend: [Value]});
+
+  //# Comonad :: TypeClass
+  //.
+  //. `TypeClass` value for [Comonad][].
+  //.
+  //. ```javascript
+  //. > Comonad.test(Identity(0))
+  //. true
+  //.
+  //. > Comonad.test([])
+  //. false
+  //. ```
+  var Comonad = $('Comonad', [Functor, Extend], {extract: [Value]});
+
+  //  Null$prototype$toString :: Null ~> () -> String
+  var Null$prototype$toString = function() {
+    return 'null';
+  };
+
+  //  Null$prototype$equals :: Null ~> Null -> Boolean
+  var Null$prototype$equals = function(other) {
+    return true;
+  };
+
+  //  Undefined$prototype$toString :: Undefined ~> () -> String
+  var Undefined$prototype$toString = function() {
+    return 'undefined';
+  };
+
+  //  Undefined$prototype$equals :: Undefined ~> Undefined -> Boolean
+  var Undefined$prototype$equals = function(other) {
+    return true;
+  };
+
+  //  Boolean$prototype$toString :: Boolean ~> () -> String
+  var Boolean$prototype$toString = function() {
+    return typeof this === 'object' ?
+      'new Boolean(' + toString(this.valueOf()) + ')' :
+      this.toString();
+  };
+
+  //  Boolean$prototype$equals :: Boolean ~> Boolean -> Boolean
+  var Boolean$prototype$equals = function(other) {
+    return typeof other === typeof this && other.valueOf() === this.valueOf();
+  };
+
+  //  Number$prototype$toString :: Number ~> () -> String
+  var Number$prototype$toString = function() {
+    return typeof this === 'object' ?
+      'new Number(' + toString(this.valueOf()) + ')' :
+      1 / this === -Infinity ? '-0' : this.toString(10);
+  };
+
+  //  Number$prototype$equals :: Number ~> Number -> Boolean
+  var Number$prototype$equals = function(other) {
+    return typeof other === 'object' ?
+      typeof this === 'object' &&
+        equals(other.valueOf(), this.valueOf()) :
+      isNaN(other) && isNaN(this) ||
+        other === this && 1 / other === 1 / this;
+  };
+
+  //  Date$prototype$toString :: Date ~> () -> String
+  var Date$prototype$toString = function() {
+    var x = isNaN(this.valueOf()) ? NaN : this.toISOString();
+    return 'new Date(' + toString(x) + ')';
+  };
+
+  //  Date$prototype$equals :: Date ~> Date -> Boolean
+  var Date$prototype$equals = function(other) {
+    return equals(other.valueOf(), this.valueOf());
+  };
+
+  //  RegExp$prototype$equals :: RegExp ~> RegExp -> Boolean
+  var RegExp$prototype$equals = function(other) {
+    return other.source === this.source &&
+           other.global === this.global &&
+           other.ignoreCase === this.ignoreCase &&
+           other.multiline === this.multiline &&
+           other.sticky === this.sticky &&
+           other.unicode === this.unicode;
+  };
+
+  //  String$empty :: () -> String
+  var String$empty = function() {
+    return '';
+  };
+
+  //  String$prototype$toString :: String ~> () -> String
+  var String$prototype$toString = function() {
+    return typeof this === 'object' ?
+      'new String(' + toString(this.valueOf()) + ')' :
+      '"' + this.replace(/\\/g, '\\\\')
+                .replace(/[\b]/g, '\\b')  // \b matches word boundary;
+                .replace(/\f/g, '\\f')    // [\b] matches backspace
+                .replace(/\n/g, '\\n')
+                .replace(/\r/g, '\\r')
+                .replace(/\t/g, '\\t')
+                .replace(/\v/g, '\\v')
+                .replace(/\0/g, '\\0')
+                .replace(/"/g, '\\"') + '"';
+  };
+
+  //  String$prototype$equals :: String ~> String -> Boolean
+  var String$prototype$equals = function(other) {
+    return typeof other === typeof this && other.valueOf() === this.valueOf();
+  };
+
+  //  String$prototype$concat :: String ~> String -> String
+  var String$prototype$concat = function(other) {
+    return this + other;
+  };
+
+  //  Array$empty :: () -> Array a
+  var Array$empty = function() {
+    return [];
+  };
+
+  //  Array$of :: a -> Array a
+  var Array$of = function(x) {
+    return [x];
+  };
+
+  //  Array$chainRec :: ((a -> c, b -> c, a) -> Array c, a) -> Array b
+  var Array$chainRec = function(f, x) {
+    var next = function(x) { return {value: x, done: false}; };
+    var done = function(x) { return {value: x, done: true}; };
+    var $todo = [x];
+    var $done = [];
+    while ($todo.length > 0) {
+      var xs = f(next, done, $todo.shift());
+      var $more = [];
+      for (var idx = 0; idx < xs.length; idx += 1) {
+        (xs[idx].done ? $done : $more).push(xs[idx].value);
+      }
+      Array.prototype.unshift.apply($todo, $more);
+    }
+    return $done;
+  };
+
+  //  Array$prototype$toString :: Array a ~> () -> String
+  var Array$prototype$toString = function() {
+    var reprs = this.map(toString);
+    var keys = Object.keys(this).sort();
+    for (var idx = 0; idx < keys.length; idx += 1) {
+      var k = keys[idx];
+      if (!/^\d+$/.test(k)) {
+        reprs.push(toString(k) + ': ' + toString(this[k]));
+      }
+    }
+    return '[' + reprs.join(', ') + ']';
+  };
+
+  //  Array$prototype$equals :: Array a ~> Array a -> Boolean
+  var Array$prototype$equals = function(other) {
+    if (other.length !== this.length) return false;
+    for (var idx = 0; idx < this.length; idx += 1) {
+      if (!equals(other[idx], this[idx])) return false;
+    }
+    return true;
+  };
+
+  //  Array$prototype$concat :: Array a ~> Array a -> Array a
+  var Array$prototype$concat = function(other) {
+    return this.concat(other);
+  };
+
+  //  Array$prototype$map :: Array a ~> (a -> b) -> Array b
+  var Array$prototype$map = function(f) {
+    return this.map(function(x) { return f(x); });
+  };
+
+  //  Array$prototype$ap :: Array a ~> Array (a -> b) -> Array b
+  var Array$prototype$ap = function(fs) {
+    var result = [];
+    for (var idx = 0; idx < fs.length; idx += 1) {
+      for (var idx2 = 0; idx2 < this.length; idx2 += 1) {
+        result.push(fs[idx](this[idx2]));
+      }
+    }
+    return result;
+  };
+
+  //  Array$prototype$chain :: Array a ~> (a -> Array b) -> Array b
+  var Array$prototype$chain = function(f) {
+    var result = [];
+    this.forEach(function(x) { Array.prototype.push.apply(result, f(x)); });
+    return result;
+  };
+
+  //  Array$prototype$reduce :: Array a ~> ((b, a) -> b, b) -> b
+  var Array$prototype$reduce = function(f, initial) {
+    return this.reduce(function(acc, x) { return f(acc, x); }, initial);
+  };
+
+  //  Array$prototype$traverse :: Applicative f => Array a ~> (a -> f b, c -> f c) -> f (Array b)
+  var Array$prototype$traverse = function(f, of) {
+    var applicative = of([]);
+    for (var idx = this.length - 1; idx >= 0; idx -= 1) {
+      applicative = ap(map(prepend, f(this[idx])), applicative);
+    }
+    return applicative;
+  };
+
+  //  Array$prototype$extend :: Array a ~> (Array a -> b) -> Array b
+  var Array$prototype$extend = function(f) {
+    return [f(this)];
+  };
+
+  //  Arguments$prototype$toString :: Arguments ~> String
+  var Arguments$prototype$toString = function() {
+    var args = Array.prototype.map.call(this, toString).join(', ');
+    return '(function () { return arguments; }(' + args + '))';
+  };
+
+  //  Arguments$prototype$equals :: Arguments ~> Arguments -> Boolean
+  var Arguments$prototype$equals = function(other) {
+    return Array$prototype$equals.call(this, other);
+  };
+
+  //  Error$prototype$toString :: Error ~> () -> String
+  var Error$prototype$toString = function() {
+    return 'new ' + this.name + '(' + toString(this.message) + ')';
+  };
+
+  //  Error$prototype$equals :: Error ~> Error -> Boolean
+  var Error$prototype$equals = function(other) {
+    return equals(other.name, this.name) &&
+           equals(other.message, this.message);
+  };
+
+  //  Object$empty :: () -> StrMap a
+  var Object$empty = function() {
+    return {};
+  };
+
+  //  Object$prototype$toString :: StrMap a ~> () -> String
+  var Object$prototype$toString = function() {
+    var reprs = [];
+    var keys = Object.keys(this).sort();
+    for (var idx = 0; idx < keys.length; idx += 1) {
+      var k = keys[idx];
+      reprs.push(toString(k) + ': ' + toString(this[k]));
+    }
+    return '{' + reprs.join(', ') + '}';
+  };
+
+  //  Object$prototype$equals :: StrMap a ~> StrMap a -> Boolean
+  var Object$prototype$equals = function(other) {
+    var self = this;
+    var keys = Object.keys(this).sort();
+    return equals(Object.keys(other).sort(), keys) &&
+           keys.every(function(k) { return equals(other[k], self[k]); });
+  };
+
+  //  Object$prototype$concat :: StrMap a ~> StrMap a -> StrMap a
+  var Object$prototype$concat = function(other) {
+    var result = {};
+    for (var k in this) result[k] = this[k];
+    for (k in other) result[k] = other[k];
+    return result;
+  };
+
+  //  Object$prototype$map :: StrMap a ~> (a -> b) -> StrMap b
+  var Object$prototype$map = function(f) {
+    var result = {};
+    for (var k in this) result[k] = f(this[k]);
+    return result;
+  };
+
+  //  Object$prototype$reduce :: StrMap a ~> ((b, a) -> b, b) -> b
+  var Object$prototype$reduce = function(f, initial) {
+    var result = initial;
+    for (var k in this) result = f(result, this[k]);
+    return result;
+  };
+
+  //  Function$of :: b -> (a -> b)
+  var Function$of = function(x) {
+    return function(_) { return x; };
+  };
+
+  //  Function$prototype$map :: (a -> b) ~> (b -> c) -> (a -> c)
+  var Function$prototype$map = function(f) {
+    var functor = this;
+    return function(x) { return f(functor(x)); };
+  };
+
+  //  Function$prototype$promap :: (b -> c) ~> (a -> b, c -> d) -> (a -> d)
+  var Function$prototype$promap = function(f, g) {
+    var profunctor = this;
+    return function(x) { return g(profunctor(f(x))); };
+  };
+
+  //  Function$prototype$ap :: (a -> b) ~> (a -> b -> c) -> (a -> c)
+  var Function$prototype$ap = function(f) {
+    var apply = this;
+    return function(x) { return f(x)(apply(x)); };
+  };
+
+  //  Function$prototype$chain :: (a -> b) ~> (b -> a -> c) -> (a -> c)
+  var Function$prototype$chain = function(f) {
+    var chain = this;
+    return function(x) { return f(chain(x))(x); };
+  };
+
+  /* eslint-disable key-spacing */
+  var implementations = {
+    Null: {
+      prototype: {
+        toString:                   Null$prototype$toString,
+        'fantasy-land/equals':      Null$prototype$equals
+      }
+    },
+    Undefined: {
+      prototype: {
+        toString:                   Undefined$prototype$toString,
+        'fantasy-land/equals':      Undefined$prototype$equals
+      }
+    },
+    Boolean: {
+      prototype: {
+        toString:                   Boolean$prototype$toString,
+        'fantasy-land/equals':      Boolean$prototype$equals
+      }
+    },
+    Number: {
+      prototype: {
+        toString:                   Number$prototype$toString,
+        'fantasy-land/equals':      Number$prototype$equals
+      }
+    },
+    Date: {
+      prototype: {
+        toString:                   Date$prototype$toString,
+        'fantasy-land/equals':      Date$prototype$equals
+      }
+    },
+    RegExp: {
+      prototype: {
+        'fantasy-land/equals':      RegExp$prototype$equals
+      }
+    },
+    String: {
+      'fantasy-land/empty':         String$empty,
+      prototype: {
+        toString:                   String$prototype$toString,
+        'fantasy-land/equals':      String$prototype$equals,
+        'fantasy-land/concat':      String$prototype$concat
+      }
+    },
+    Array: {
+      'fantasy-land/empty':         Array$empty,
+      'fantasy-land/of':            Array$of,
+      'fantasy-land/chainRec':      Array$chainRec,
+      prototype: {
+        toString:                   Array$prototype$toString,
+        'fantasy-land/equals':      Array$prototype$equals,
+        'fantasy-land/concat':      Array$prototype$concat,
+        'fantasy-land/map':         Array$prototype$map,
+        'fantasy-land/ap':          Array$prototype$ap,
+        'fantasy-land/chain':       Array$prototype$chain,
+        'fantasy-land/reduce':      Array$prototype$reduce,
+        'fantasy-land/traverse':    Array$prototype$traverse,
+        'fantasy-land/extend':      Array$prototype$extend
+      }
+    },
+    Arguments: {
+      prototype: {
+        toString:                   Arguments$prototype$toString,
+        'fantasy-land/equals':      Arguments$prototype$equals
+      }
+    },
+    Error: {
+      prototype: {
+        toString:                   Error$prototype$toString,
+        'fantasy-land/equals':      Error$prototype$equals
+      }
+    },
+    Object: {
+      'fantasy-land/empty':         Object$empty,
+      prototype: {
+        toString:                   Object$prototype$toString,
+        'fantasy-land/equals':      Object$prototype$equals,
+        'fantasy-land/concat':      Object$prototype$concat,
+        'fantasy-land/map':         Object$prototype$map,
+        'fantasy-land/reduce':      Object$prototype$reduce
+      }
+    },
+    Function: {
+      'fantasy-land/of':            Function$of,
+      prototype: {
+        'fantasy-land/map':         Function$prototype$map,
+        'fantasy-land/promap':      Function$prototype$promap,
+        'fantasy-land/ap':          Function$prototype$ap,
+        'fantasy-land/chain':       Function$prototype$chain
+      }
+    }
+  };
+  /* eslint-enable key-spacing */
+
+  //# toString :: a -> String
+  //.
+  //. Returns a useful string representation of its argument.
+  //.
+  //. Dispatches to the argument's `toString` method if appropriate.
+  //.
+  //. Where practical, `equals(eval(toString(x)), x) = true`.
+  //.
+  //. `toString` implementations are provided for the following built-in types:
+  //. Null, Undefined, Boolean, Number, Date, String, Array, Arguments, Error,
+  //. and Object.
+  //.
+  //. ```javascript
+  //. > toString(-0)
+  //. '-0'
+  //.
+  //. > toString(['foo', 'bar', 'baz'])
+  //. '["foo", "bar", "baz"]'
+  //.
+  //. > toString({x: 1, y: 2, z: 3})
+  //. '{"x": 1, "y": 2, "z": 3}'
+  //.
+  //. > toString(Cons(1, Cons(2, Cons(3, Nil))))
+  //. 'Cons(1, Cons(2, Cons(3, Nil)))'
+  //. ```
+  var toString = (function() {
+    //  $seen :: Array Any
+    var $seen = [];
+
+    var call = function(method, x) {
+      $seen.push(x);
+      try { return method.call(x); } finally { $seen.pop(); }
+    };
+
+    return function toString(x) {
+      if ($seen.indexOf(x) >= 0) return '<Circular>';
+
+      var xType = type(x);
+      if (xType === 'Object') {
+        var result;
+        try { result = call(x.toString, x); } catch (err) {}
+        if (result != null && result !== '[object Object]') return result;
+      }
+
+      return call(implPath([xType, 'prototype', 'toString']) || x.toString, x);
+    };
+  }());
+
+  //# equals :: (a, b) -> Boolean
+  //.
+  //. Returns `true` if its arguments are of the same type and equal according
+  //. to the type's [`fantasy-land/equals`][] method; `false` otherwise.
+  //.
+  //. `fantasy-land/equals` implementations are provided for the following
+  //. built-in types: Null, Undefined, Boolean, Number, Date, RegExp, String,
+  //. Array, Arguments, Error, and Object.
+  //.
+  //. ```javascript
+  //. > equals(0, -0)
+  //. false
+  //.
+  //. > equals(NaN, NaN)
+  //. true
+  //.
+  //. > equals(Cons('foo', Cons('bar', Nil)), Cons('foo', Cons('bar', Nil)))
+  //. true
+  //.
+  //. > equals(Cons('foo', Cons('bar', Nil)), Cons('bar', Cons('foo', Nil)))
+  //. false
+  //. ```
+  var equals = (function() {
+    //  eq :: Setoid a => a -> a -> Boolean
+    var eq = Setoid.methods.equals;
+
+    //  $seen :: Array Any
+    var $seen = [];
+
+    //  equal :: (a, b) -> Boolean
+    var equal = function(x, y) {
+      $seen.push(x, y);
+      try {
+        return Setoid.test(x) && Setoid.test(y) && eq(x)(y) && eq(y)(x);
+      } finally {
+        $seen.splice(-2, 2);
+      }
+    };
+
+    return function equals(x, y) {
+      return Object(x) === Object(y) || type(x) === type(y)
+                                     && $seen.indexOf(x) < 0
+                                     && $seen.indexOf(y) < 0
+                                     && equal(x, y);
+    };
+  }());
+
+  //# concat :: Semigroup a => (a, a) -> a
+  //.
+  //. Function wrapper for [`fantasy-land/concat`][].
+  //.
+  //. `fantasy-land/concat` implementations are provided for the following
+  //. built-in types: String, Array, and Object.
+  //.
+  //. ```javascript
+  //. > concat('abc', 'def')
+  //. 'abcdef'
+  //.
+  //. > concat([1, 2, 3], [4, 5, 6])
+  //. [1, 2, 3, 4, 5, 6]
+  //.
+  //. > concat({x: 1, y: 2}, {y: 3, z: 4})
+  //. {x: 1, y: 3, z: 4}
+  //.
+  //. > concat(Cons('foo', Cons('bar', Cons('baz', Nil))), Cons('quux', Nil))
+  //. Cons('foo', Cons('bar', Cons('baz', Cons('quux', Nil))))
+  //. ```
+  var concat = function concat(x, y) {
+    return Semigroup.methods.concat(x)(y);
+  };
+
+  //# empty :: Monoid m => TypeRep m -> m
+  //.
+  //. Function wrapper for [`fantasy-land/empty`][].
+  //.
+  //. `fantasy-land/empty` implementations are provided for the following
+  //. built-in types: String, Array, and Object.
+  //.
+  //. ```javascript
+  //. > empty(String)
+  //. ''
+  //.
+  //. > empty(Array)
+  //. []
+  //.
+  //. > empty(Object)
+  //. {}
+  //.
+  //. > empty(List)
+  //. Nil
+  //. ```
+  var empty = function empty(typeRep) {
+    return Monoid.functions.empty(typeRep)();
+  };
+
+  //# map :: Functor f => (a -> b, f a) -> f b
+  //.
+  //. Function wrapper for [`fantasy-land/map`][].
+  //.
+  //. `fantasy-land/map` implementations are provided for the following
+  //. built-in types: Array, Object, and Function.
+  //.
+  //. ```javascript
+  //. > map(Math.sqrt, [1, 4, 9])
+  //. [1, 2, 3]
+  //.
+  //. > map(Math.sqrt, {x: 1, y: 4, z: 9})
+  //. {x: 1, y: 2, z: 3}
+  //.
+  //. > map(Math.sqrt, s => s.length)('Sanctuary')
+  //. 3
+  //.
+  //. > map(Math.sqrt, Tuple('foo', 64))
+  //. Tuple('foo', 8)
+  //.
+  //. > map(Math.sqrt, Nil)
+  //. Nil
+  //.
+  //. > map(Math.sqrt, Cons(1, Cons(4, Cons(9, Nil))))
+  //. Cons(1, Cons(2, Cons(3, Nil)))
+  //. ```
+  var map = function map(f, functor) {
+    return Functor.methods.map(functor)(f);
+  };
+
+  //# bimap :: Bifunctor f => (a -> b, c -> d, f a c) -> f b d
+  //.
+  //. Function wrapper for [`fantasy-land/bimap`][].
+  //.
+  //. ```javascript
+  //. > bimap(s => s.toUpperCase(), Math.sqrt, Tuple('foo', 64))
+  //. Tuple('FOO', 8)
+  //. ```
+  var bimap = function bimap(f, g, bifunctor) {
+    return Bifunctor.methods.bimap(bifunctor)(f, g);
+  };
+
+  //# promap :: Profunctor p => (a -> b, c -> d, p b c) -> p a d
+  //.
+  //. Function wrapper for [`fantasy-land/promap`][].
+  //.
+  //. `fantasy-land/promap` implementations are provided for the following
+  //. built-in types: Function.
+  //.
+  //. ```javascript
+  //. > promap(Math.abs, x => x + 1, Math.sqrt)(-100)
+  //. 11
+  //. ```
+  var promap = function promap(f, g, profunctor) {
+    return Profunctor.methods.promap(profunctor)(f, g);
+  };
+
+  //# ap :: Apply f => (f (a -> b), f a) -> f b
+  //.
+  //. Function wrapper for [`fantasy-land/ap`][].
+  //.
+  //. `fantasy-land/ap` implementations are provided for the following
+  //. built-in types: Array and Function.
+  //.
+  //. ```javascript
+  //. > ap([Math.sqrt, x => x * x], [1, 4, 9, 16, 25])
+  //. [1, 2, 3, 4, 5, 1, 16, 81, 256, 625]
+  //.
+  //. > ap(s => n => s.slice(0, n), s => Math.ceil(s.length / 2))('Haskell')
+  //. 'Hask'
+  //.
+  //. > ap(Identity(Math.sqrt), Identity(64))
+  //. Identity(8)
+  //.
+  //. > ap(Cons(Math.sqrt, Cons(x => x * x, Nil)), Cons(16, Cons(100, Nil)))
+  //. Cons(4, Cons(10, Cons(256, Cons(10000, Nil))))
+  //. ```
+  var ap = function ap(applyF, applyX) {
+    return Apply.methods.ap(applyX)(applyF);
+  };
+
+  //# of :: Applicative f => (TypeRep f, a) -> f a
+  //.
+  //. Function wrapper for [`fantasy-land/of`][].
+  //.
+  //. `fantasy-land/of` implementations are provided for the following
+  //. built-in types: Array and Function.
+  //.
+  //. ```javascript
+  //. > of(Array, 42)
+  //. [42]
+  //.
+  //. > of(Function, 42)(null)
+  //. 42
+  //.
+  //. > of(List, 42)
+  //. Cons(42, Nil)
+  //. ```
+  var of = function of(typeRep, x) {
+    return Applicative.functions.of(typeRep)(x);
+  };
+
+  //# chain :: Chain m => (a -> m b, m a) -> m b
+  //.
+  //. Function wrapper for [`fantasy-land/chain`][].
+  //.
+  //. `fantasy-land/chain` implementations are provided for the following
+  //. built-in types: Array and Function.
+  //.
+  //. ```javascript
+  //. > chain(x => [x, x], [1, 2, 3])
+  //. [1, 1, 2, 2, 3, 3]
+  //.
+  //. > chain(x => x % 2 == 1 ? of(List, x) : Nil, Cons(1, Cons(2, Cons(3, Nil))))
+  //. Cons(1, Cons(3, Nil))
+  //.
+  //. > chain(n => s => s.slice(0, n), s => Math.ceil(s.length / 2))('Haskell')
+  //. 'Hask'
+  //. ```
+  var chain = function chain(f, chain) {
+    return Chain.methods.chain(chain)(f);
+  };
+
+  //# chainRec :: ChainRec m => (TypeRep m, (a -> c, b -> c, a) -> m c, a) -> m b
+  //.
+  //. Function wrapper for [`fantasy-land/chainRec`][].
+  //.
+  //. `fantasy-land/chainRec` implementations are provided for the following
+  //. built-in types: Array.
+  //.
+  //. ```javascript
+  //. > chainRec(
+  //. .   Array,
+  //. .   (next, done, s) => s.length == 2 ? [s + '!', s + '?'].map(done)
+  //. .                                    : [s + 'o', s + 'n'].map(next),
+  //. .   ''
+  //. . )
+  //. ['oo!', 'oo?', 'on!', 'on?', 'no!', 'no?', 'nn!', 'nn?']
+  //. ```
+  var chainRec = function chainRec(typeRep, f, x) {
+    return ChainRec.functions.chainRec(typeRep)(f, x);
+  };
+
+  //# filter :: (Applicative f, Foldable f, Monoid (f a)) => (a -> Boolean, f a) -> f a
+  //.
+  //. Filters its second argument in accordance with the given predicate.
+  //.
+  //. This function is derived from [`empty`](#empty), [`of`](#of), and
+  //. [`reduce`](#reduce).
+  //.
+  //. See also [`filterM`](#filterM).
+  //.
+  //. ```javascript
+  //. > filter(x => x % 2 == 1, [1, 2, 3])
+  //. [1, 3]
+  //.
+  //. > filter(x => x % 2 == 1, Cons(1, Cons(2, Cons(3, Nil))))
+  //. Cons(1, Cons(3, Nil))
+  //. ```
+  var filter = function filter(pred, m) {
+    var M$empty = empty(orConstructor('fantasy-land/empty', m));
+    var M$of = orConstructor('fantasy-land/of', m);
+    var f = function(m, x) { return pred(x) ? concat(m, of(M$of, x)) : m; };
+    return reduce(f, M$empty, m);
+  };
+
+  //# filterM :: (Monad m, Monoid (m a)) => (a -> Boolean, m a) -> m a
+  //.
+  //. Filters its second argument in accordance with the given predicate.
+  //.
+  //. This function is derived from [`empty`](#empty), [`of`](#of), and
+  //. [`chain`](#chain).
+  //.
+  //. See also [`filter`](#filter).
+  //.
+  //. ```javascript
+  //. > filterM(x => x % 2 == 1, [1, 2, 3])
+  //. [1, 3]
+  //.
+  //. > filterM(x => x % 2 == 1, Cons(1, Cons(2, Cons(3, Nil))))
+  //. Cons(1, Cons(3, Nil))
+  //. ```
+  var filterM = function filterM(pred, m) {
+    var M$empty = empty(orConstructor('fantasy-land/empty', m));
+    var M$of = orConstructor('fantasy-land/of', m);
+    var f = function(x) { return pred(x) ? of(M$of, x) : M$empty; };
+    return chain(f, m);
+  };
+
+  //# reduce :: Foldable f => ((b, a) -> b, b, f a) -> b
+  //.
+  //. Function wrapper for [`fantasy-land/reduce`][].
+  //.
+  //. `fantasy-land/reduce` implementations are provided for the following
+  //. built-in types: Array and Object.
+  //.
+  //. ```javascript
+  //. > reduce((xs, x) => [x].concat(xs), [], [1, 2, 3])
+  //. [3, 2, 1]
+  //.
+  //. > reduce(concat, '', Cons('foo', Cons('bar', Cons('baz', Nil))))
+  //. 'foobarbaz'
+  //. ```
+  var reduce = function reduce(f, x, foldable) {
+    return Foldable.methods.reduce(foldable)(f, x);
+  };
+
+  //# traverse :: (Applicative f, Traversable t) => (a -> f a, b -> f c, t b) -> f (t c)
+  //.
+  //. Function wrapper for [`fantasy-land/traverse`][].
+  //.
+  //. `fantasy-land/traverse` implementations are provided for the following
+  //. built-in types: Array.
+  //.
+  //. See also [`sequence`](#sequence).
+  //.
+  //. ```javascript
+  //. > traverse(x => [x], x => x, [[1, 2, 3], [4, 5]])
+  //. [[1, 4], [1, 5], [2, 4], [2, 5], [3, 4], [3, 5]]
+  //.
+  //. > traverse(Identity, x => Identity(x + 1), [1, 2, 3])
+  //. Identity([2, 3, 4])
+  //. ```
+  var traverse = function traverse(of, f, traversable) {
+    return Traversable.methods.traverse(traversable)(f, of);
+  };
+
+  //# sequence :: (Applicative f, Traversable t) => (a -> f a, t (f b)) -> f (t b)
+  //.
+  //. Inverts the given `t (f b)` to produce an `f (t b)`.
+  //.
+  //. This function is derived from [`traverse`](#traverse).
+  //.
+  //. ```javascript
+  //. > sequence(x => [x], Identity([1, 2, 3]))
+  //. [Identity(1), Identity(2), Identity(3)]
+  //.
+  //. > sequence(Identity, [Identity(1), Identity(2), Identity(3)])
+  //. Identity([1, 2, 3])
+  //. ```
+  var sequence = function sequence(of, traversable) {
+    return traverse(of, identity, traversable);
+  };
+
+  //# extend :: Extend w => (w a -> b, w a) -> w b
+  //.
+  //. Function wrapper for [`fantasy-land/extend`][].
+  //.
+  //. `fantasy-land/extend` implementations are provided for the following
+  //. built-in types: Array.
+  //.
+  //. ```javascript
+  //. > extend(xs => xs.length, ['foo', 'bar', 'baz', 'quux'])
+  //. [4]
+  //. ```
+  var extend = function extend(f, extend) {
+    return Extend.methods.extend(extend)(f);
+  };
+
+  //# extract :: Comonad w => w a -> a
+  //.
+  //. Function wrapper for [`fantasy-land/extract`][].
+  //.
+  //. ```javascript
+  //. > extract(Identity(42))
+  //. 42
+  //. ```
+  var extract = function extract(comonad) {
+    return Comonad.methods.extract(comonad)();
+  };
+
+  return {
+    TypeClass: TypeClass,
+    Setoid: Setoid,
+    Semigroup: Semigroup,
+    Monoid: Monoid,
+    Functor: Functor,
+    Bifunctor: Bifunctor,
+    Profunctor: Profunctor,
+    Apply: Apply,
+    Applicative: Applicative,
+    Chain: Chain,
+    ChainRec: ChainRec,
+    Monad: Monad,
+    Foldable: Foldable,
+    Traversable: Traversable,
+    Extend: Extend,
+    Comonad: Comonad,
+    toString: toString,
+    equals: equals,
+    concat: concat,
+    empty: empty,
+    map: map,
+    bimap: bimap,
+    promap: promap,
+    ap: ap,
+    of: of,
+    chain: chain,
+    chainRec: chainRec,
+    filter: filter,
+    filterM: filterM,
+    reduce: reduce,
+    traverse: traverse,
+    sequence: sequence,
+    extend: extend,
+    extract: extract
+  };
+
+}));
+
+//. [Applicative]:              https://github.com/fantasyland/fantasy-land#applicative
+//. [Apply]:                    https://github.com/fantasyland/fantasy-land#apply
+//. [Bifunctor]:                https://github.com/fantasyland/fantasy-land#bifunctor
+//. [Chain]:                    https://github.com/fantasyland/fantasy-land#chain
+//. [ChainRec]:                 https://github.com/fantasyland/fantasy-land#chainrec
+//. [Comonad]:                  https://github.com/fantasyland/fantasy-land#comonad
+//. [Extend]:                   https://github.com/fantasyland/fantasy-land#extend
+//. [FL]:                       https://github.com/fantasyland/fantasy-land
+//. [Foldable]:                 https://github.com/fantasyland/fantasy-land#foldable
+//. [Functor]:                  https://github.com/fantasyland/fantasy-land#functor
+//. [Monad]:                    https://github.com/fantasyland/fantasy-land#monad
+//. [Monoid]:                   https://github.com/fantasyland/fantasy-land#monoid
+//. [Profunctor]:               https://github.com/fantasyland/fantasy-land#profunctor
+//. [Semigroup]:                https://github.com/fantasyland/fantasy-land#semigroup
+//. [Setoid]:                   https://github.com/fantasyland/fantasy-land#setoid
+//. [Traversable]:              https://github.com/fantasyland/fantasy-land#traversable
+//. [`fantasy-land/ap`]:        https://github.com/fantasyland/fantasy-land#ap-method
+//. [`fantasy-land/bimap`]:     https://github.com/fantasyland/fantasy-land#bimap-method
+//. [`fantasy-land/chain`]:     https://github.com/fantasyland/fantasy-land#chain-method
+//. [`fantasy-land/chainRec`]:  https://github.com/fantasyland/fantasy-land#chainrec-method
+//. [`fantasy-land/concat`]:    https://github.com/fantasyland/fantasy-land#concat-method
+//. [`fantasy-land/empty`]:     https://github.com/fantasyland/fantasy-land#empty-method
+//. [`fantasy-land/equals`]:    https://github.com/fantasyland/fantasy-land#equals-method
+//. [`fantasy-land/extend`]:    https://github.com/fantasyland/fantasy-land#extend-method
+//. [`fantasy-land/extract`]:   https://github.com/fantasyland/fantasy-land#extract-method
+//. [`fantasy-land/map`]:       https://github.com/fantasyland/fantasy-land#map-method
+//. [`fantasy-land/of`]:        https://github.com/fantasyland/fantasy-land#of-method
+//. [`fantasy-land/promap`]:    https://github.com/fantasyland/fantasy-land#promap-method
+//. [`fantasy-land/reduce`]:    https://github.com/fantasyland/fantasy-land#reduce-method
+//. [`fantasy-land/traverse`]:  https://github.com/fantasyland/fantasy-land#traverse-method
+//. [type-classes]:             https://github.com/sanctuary-js/sanctuary-def#type-classes

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "sanctuary-type-classes",
+  "version": "0.0.0",
+  "description": "Standard library for Fantasy Land",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/sanctuary-js/sanctuary-type-classes.git"
+  },
+  "scripts": {
+    "test": "make lint test"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "doctest": "0.10.x",
+    "eslint": "2.9.x",
+    "fantasy-land": "1.0.1",
+    "istanbul": "0.4.x",
+    "mocha": "2.x.x",
+    "sanctuary-style": "0.2.x",
+    "transcribe": "0.5.x",
+    "xyz": "1.0.x"
+  },
+  "files": [
+    "/LICENSE",
+    "/README.md",
+    "/index.js",
+    "/package.json"
+  ]
+}

--- a/scripts/predoctest
+++ b/scripts/predoctest
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var fs = require('fs');
+
+
+//  definitions :: Array String
+var definitions = [
+  "global.Identity = require('./test/Identity')",
+  "global.List = require('./test/List')",
+  'global.Nil = List.Nil',
+  'global.Cons = List.Cons',
+  "global.Tuple = require('./test/Tuple')"
+];
+
+process.stdout.write(
+  fs.readFileSync('index.js', {encoding: 'utf8'})
+  .replace(/^(.*)( ```javascript\n)\1 > (.*)/m,
+           '$1$2$1 > ' + definitions.join(', ') + ', $3')
+  .split(/(```javascript[\s\S]*?```)/g)
+  .map(function(s, idx) {
+    return idx % 2 === 1 ? s : s.replace(/^([ ]*[/][/][.]) >/gm, '$1');
+  })
+  .join('')
+);

--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+rm -f README.md
+make
+git add LICENSE README.md

--- a/test/Identity.js
+++ b/test/Identity.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var FL = require('fantasy-land');
+
+var Z = require('..');
+
+
+//  Identity :: a -> Identity a
+var Identity = function Identity(value) {
+  if (!(this instanceof Identity)) return new Identity(value);
+  this.value = value;
+};
+
+Identity[FL.of] = Identity;
+
+Identity.prototype['@@type'] = 'sanctuary-type-classes/Identity';
+
+Identity.prototype[FL.equals] = function(other) {
+  return Z.equals(other.value, this.value);
+};
+
+Identity.prototype[FL.concat] = function(other) {
+  return Identity(Z.concat(this.value, other.value));
+};
+
+Identity.prototype[FL.map] = function(f) {
+  return Identity(f(this.value));
+};
+
+Identity.prototype[FL.ap] = function(other) {
+  return Z.map(other.value, this);
+};
+
+Identity.prototype[FL.chain] = function(f) {
+  return f(this.value);
+};
+
+Identity.prototype[FL.reduce] = function(f, x) {
+  return f(x, this.value);
+};
+
+Identity.prototype[FL.traverse] = function(f, of) {
+  return Z.map(Identity, f(this.value));
+};
+
+Identity.prototype[FL.extend] = function(f) {
+  return Identity(f(this));
+};
+
+Identity.prototype[FL.extract] = function() {
+  return this.value;
+};
+
+Identity.prototype.inspect =
+Identity.prototype.toString = function() {
+  return 'Identity(' + Z.toString(this.value) + ')';
+};
+
+module.exports = Identity;

--- a/test/List.js
+++ b/test/List.js
@@ -1,0 +1,94 @@
+'use strict';
+
+var FL = require('fantasy-land');
+
+var Z = require('..');
+
+var curry2 = require('./curry2');
+var eq = require('./eq');
+
+
+var sentinel = {};
+
+var List = function List(x, tag, head, tail) {
+  if (x !== sentinel) {
+    throw new Error('List is not a data constructor (use Nil or Cons)');
+  }
+  this.tag = tag;
+  if (tag === 'Cons') {
+    this.head = head;
+    this.tail = tail;
+  }
+};
+
+//  Nil :: List a
+var Nil = List.Nil = new List(sentinel, 'Nil');
+
+//  Cons :: (a, List a) -> List a
+var Cons = List.Cons = function(head, tail) {
+  eq(arguments.length, 2);
+  return new List(sentinel, 'Cons', head, tail);
+};
+
+List[FL.empty] = function() { return Nil; };
+
+List[FL.of] = function(x) { return Cons(x, Nil); };
+
+List.prototype['@@type'] = 'sanctuary-type-classes/List';
+
+List.prototype[FL.equals] = function(other) {
+  return this.tag === 'Nil' ?
+    other.tag === 'Nil' :
+    other.tag === 'Cons' &&
+      Z.equals(other.head, this.head) &&
+      Z.equals(other.tail, this.tail);
+};
+
+List.prototype[FL.concat] = function(other) {
+  return this.tag === 'Nil' ?
+    other :
+    Cons(this.head, Z.concat(this.tail, other));
+};
+
+List.prototype[FL.empty] = List[FL.empty];
+
+List.prototype[FL.map] = function(f) {
+  return this.tag === 'Nil' ?
+    Nil :
+    Cons(f(this.head), Z.map(f, this.tail));
+};
+
+List.prototype[FL.ap] = function(other) {
+  return this.tag === 'Nil' || other.tag === 'Nil' ?
+    Nil :
+    Z.concat(Z.map(other.head, this), Z.ap(other.tail, this));
+};
+
+List.prototype[FL.of] = List[FL.of];
+
+List.prototype[FL.chain] = function(f) {
+  return this.tag === 'Nil' ?
+    Nil :
+    Z.concat(f(this.head), Z.chain(f, this.tail));
+};
+
+List.prototype[FL.reduce] = function(f, x) {
+  return this.tag === 'Nil' ?
+    x :
+    Z.reduce(f, f(x, this.head), this.tail);
+};
+
+List.prototype[FL.traverse] = function(f, of) {
+  return this.tag === 'Nil' ?
+    of(Nil) :
+    Z.ap(Z.map(curry2(Cons), f(this.head)), Z.traverse(of, f, this.tail));
+};
+
+List.prototype.inspect =
+List.prototype.toString = function() {
+  return this.tag === 'Nil' ?
+    'Nil' :
+    'Cons(' + Z.toString(this.head) + ', ' + Z.toString(this.tail) + ')';
+};
+
+module.exports = List;

--- a/test/Tuple.js
+++ b/test/Tuple.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var FL = require('fantasy-land');
+
+var Z = require('..');
+
+
+//  Tuple :: (a, b) -> Tuple a b
+var Tuple = function Tuple(_1, _2) {
+  if (!(this instanceof Tuple)) return new Tuple(_1, _2);
+  this._1 = _1;
+  this._2 = _2;
+};
+
+Tuple.prototype['@@type'] = 'sanctuary-type-classes/Tuple';
+
+Tuple.prototype[FL.equals] = function(other) {
+  return Z.equals(other._1, this._1) && Z.equals(other._2, this._2);
+};
+
+Tuple.prototype[FL.map] = function(f) {
+  return Tuple(this._1, f(this._2));
+};
+
+Tuple.prototype[FL.bimap] = function(f, g) {
+  return Tuple(f(this._1), g(this._2));
+};
+
+Tuple.prototype.inspect =
+Tuple.prototype.toString = function() {
+  return 'Tuple(' + Z.toString(this._1) + ', ' + Z.toString(this._2) + ')';
+};
+
+module.exports = Tuple;

--- a/test/curry2.js
+++ b/test/curry2.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var eq = require('./eq');
+
+
+//  curry2 :: ((a, b) -> c) -> (a -> b -> c)
+module.exports = function curry2(f) {
+  eq(arguments.length, 1);
+  return function(x) {
+    eq(arguments.length, 1);
+    return function(y) {
+      eq(arguments.length, 1);
+      return f(x, y);
+    };
+  };
+};

--- a/test/eq.js
+++ b/test/eq.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var assert = require('assert');
+
+var Z = require('..');
+
+
+//  eq :: (Any, Any) -> Undefined !
+module.exports = function eq(actual, expected) {
+  assert.strictEqual(arguments.length, 2);
+  assert.strictEqual(Z.toString(actual), Z.toString(expected));
+  assert.strictEqual(Z.equals(actual, expected), true);
+};

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,673 @@
+'use strict';
+
+/* eslint-env mocha */
+/* eslint max-len: "off" */
+
+var Z = require('..');
+
+var Identity = require('./Identity');
+var List = require('./List');
+var Tuple = require('./Tuple');
+var eq = require('./eq');
+
+
+var Nil = List.Nil;
+var Cons = List.Cons;
+
+
+//  Array$of :: a -> Array a
+var Array$of = function(x) {
+  eq(arguments.length, 1);
+  return Z.of(Array, x);
+};
+
+//  List$of :: a -> List a
+var List$of = function(x) {
+  eq(arguments.length, 1);
+  return Z.of(List, x);
+};
+
+//  abs :: Number -> Number
+var abs = function(x) {
+  eq(arguments.length, 1);
+  return Math.abs(x);
+};
+
+//  add :: (Number, Number) -> Number
+var add = function(x, y) {
+  eq(arguments.length, 2);
+  return x + y;
+};
+
+//  args :: (Any...) -> Arguments
+var args = function() {
+  return arguments;
+};
+
+//  circular :: Pair String (Pair String (Pair String ...))
+var circular = ['foo']; circular[1] = circular;
+
+//  duplicate :: a -> Pair a a
+var duplicate = function(x) {
+  eq(arguments.length, 1);
+  return [x, x];
+};
+
+//  identInc :: Number -> Identity Number
+var identInc = function(x) {
+  eq(arguments.length, 1);
+  return Identity(x + 1);
+};
+
+//  identity :: a -> a
+var identity = function(x) {
+  eq(arguments.length, 1);
+  return x;
+};
+
+//  inc :: Number -> Number
+var inc = function(x) {
+  eq(arguments.length, 1);
+  return x + 1;
+};
+
+//  length :: List a -> Integer
+var length = function(xs) {
+  eq(arguments.length, 1);
+  return xs.length;
+};
+
+var node1 = {id: 1, rels: []};
+var node2 = {id: 2, rels: []};
+node1.rels.push({type: 'child', value: node2});
+node2.rels.push({type: 'parent', value: node1});
+
+//  odd :: Integer -> Boolean
+var odd = function(x) {
+  eq(arguments.length, 1);
+  return x % 2 === 1;
+};
+
+//  pow :: Number -> Number -> Number
+var pow = function(base) {
+  eq(arguments.length, 1);
+  return function(exp) {
+    eq(arguments.length, 1);
+    return Math.pow(base, exp);
+  };
+};
+
+//  range :: Integer -> Array Integer
+var range = function(n) {
+  eq(arguments.length, 1);
+  var result = [];
+  for (var m = 0; m < n; m += 1) result.push(m);
+  return result;
+};
+
+//  repeat :: Integer -> a -> Array a
+var repeat = function(n) {
+  eq(arguments.length, 1);
+  return function(x) {
+    eq(arguments.length, 1);
+    var result = [];
+    for (var m = 0; m < n; m += 1) result.push(x);
+    return result;
+  };
+};
+
+//  square :: Number -> Number
+var square = function(x) {
+  eq(arguments.length, 1);
+  return x * x;
+};
+
+//  toUpper :: String -> String
+var toUpper = function(s) {
+  eq(arguments.length, 1);
+  return s.toUpperCase();
+};
+
+
+test('TypeClass', function() {
+  eq(typeof Z.TypeClass, 'function');
+  eq(Z.TypeClass.length, 3);
+
+  //  hasMethod :: String -> a -> Boolean
+  var hasMethod = function(name) {
+    return function(x) {
+      return x != null && typeof x[name] === 'function';
+    };
+  };
+
+  //  Foo :: TypeClass
+  var Foo = Z.TypeClass('my-package/Foo', [], hasMethod('foo'));
+
+  //  Bar :: TypeClass
+  var Bar = Z.TypeClass('my-package/Bar', [Foo], hasMethod('bar'));
+
+  eq(Foo['@@type'], 'sanctuary-type-classes/TypeClass');
+  eq(Foo.name, 'my-package/Foo');
+  eq(Foo.test(null), false);
+  eq(Foo.test({}), false);
+  eq(Foo.test({foo: function() {}}), true);
+  eq(Foo.test({bar: function() {}}), false);
+  eq(Foo.test({foo: function() {}, bar: function() {}}), true);
+
+  eq(Bar['@@type'], 'sanctuary-type-classes/TypeClass');
+  eq(Bar.name, 'my-package/Bar');
+  eq(Bar.test(null), false);
+  eq(Bar.test({}), false);
+  eq(Bar.test({foo: function() {}}), false);
+  eq(Bar.test({bar: function() {}}), false);
+  eq(Bar.test({foo: function() {}, bar: function() {}}), true);
+});
+
+test('Setoid', function() {
+  eq(Z.Setoid['@@type'], 'sanctuary-type-classes/TypeClass');
+  eq(Z.Setoid.name, 'sanctuary-type-classes/Setoid');
+  eq(Z.Setoid.test(null), true);
+  eq(Z.Setoid.test(''), true);
+  eq(Z.Setoid.test([]), true);
+  eq(Z.Setoid.test({}), true);
+  eq(Z.Setoid.test({'@@type': 'my-package/Quux'}), false);
+});
+
+test('Semigroup', function() {
+  eq(Z.Semigroup['@@type'], 'sanctuary-type-classes/TypeClass');
+  eq(Z.Semigroup.name, 'sanctuary-type-classes/Semigroup');
+  eq(Z.Semigroup.test(null), false);
+  eq(Z.Semigroup.test(''), true);
+  eq(Z.Semigroup.test([]), true);
+  eq(Z.Semigroup.test({}), true);
+});
+
+test('Monoid', function() {
+  eq(Z.Monoid['@@type'], 'sanctuary-type-classes/TypeClass');
+  eq(Z.Monoid.name, 'sanctuary-type-classes/Monoid');
+  eq(Z.Monoid.test(null), false);
+  eq(Z.Monoid.test(''), true);
+  eq(Z.Monoid.test([]), true);
+  eq(Z.Monoid.test({}), true);
+});
+
+test('Functor', function() {
+  eq(Z.Functor['@@type'], 'sanctuary-type-classes/TypeClass');
+  eq(Z.Functor.name, 'sanctuary-type-classes/Functor');
+  eq(Z.Functor.test(null), false);
+  eq(Z.Functor.test(''), false);
+  eq(Z.Functor.test([]), true);
+  eq(Z.Functor.test({}), true);
+});
+
+test('Bifunctor', function() {
+  eq(Z.Bifunctor['@@type'], 'sanctuary-type-classes/TypeClass');
+  eq(Z.Bifunctor.name, 'sanctuary-type-classes/Bifunctor');
+  eq(Z.Bifunctor.test(null), false);
+  eq(Z.Bifunctor.test(''), false);
+  eq(Z.Bifunctor.test([]), false);
+  eq(Z.Bifunctor.test({}), false);
+  eq(Z.Bifunctor.test(Tuple('abc', 123)), true);
+});
+
+test('Profunctor', function() {
+  eq(Z.Profunctor['@@type'], 'sanctuary-type-classes/TypeClass');
+  eq(Z.Profunctor.name, 'sanctuary-type-classes/Profunctor');
+  eq(Z.Profunctor.test(null), false);
+  eq(Z.Profunctor.test(''), false);
+  eq(Z.Profunctor.test([]), false);
+  eq(Z.Profunctor.test({}), false);
+  eq(Z.Profunctor.test(Math.abs), true);
+});
+
+test('Apply', function() {
+  eq(Z.Apply['@@type'], 'sanctuary-type-classes/TypeClass');
+  eq(Z.Apply.name, 'sanctuary-type-classes/Apply');
+  eq(Z.Apply.test(null), false);
+  eq(Z.Apply.test(''), false);
+  eq(Z.Apply.test([]), true);
+  eq(Z.Apply.test({}), false);
+});
+
+test('Applicative', function() {
+  eq(Z.Applicative['@@type'], 'sanctuary-type-classes/TypeClass');
+  eq(Z.Applicative.name, 'sanctuary-type-classes/Applicative');
+  eq(Z.Applicative.test(null), false);
+  eq(Z.Applicative.test(''), false);
+  eq(Z.Applicative.test([]), true);
+  eq(Z.Applicative.test({}), false);
+});
+
+test('Chain', function() {
+  eq(Z.Chain['@@type'], 'sanctuary-type-classes/TypeClass');
+  eq(Z.Chain.name, 'sanctuary-type-classes/Chain');
+  eq(Z.Chain.test(null), false);
+  eq(Z.Chain.test(''), false);
+  eq(Z.Chain.test([]), true);
+  eq(Z.Chain.test({}), false);
+});
+
+test('ChainRec', function() {
+  eq(Z.ChainRec['@@type'], 'sanctuary-type-classes/TypeClass');
+  eq(Z.ChainRec.name, 'sanctuary-type-classes/ChainRec');
+  eq(Z.ChainRec.test(null), false);
+  eq(Z.ChainRec.test(''), false);
+  eq(Z.ChainRec.test([]), true);
+  eq(Z.ChainRec.test({}), false);
+});
+
+test('Monad', function() {
+  eq(Z.Monad['@@type'], 'sanctuary-type-classes/TypeClass');
+  eq(Z.Monad.name, 'sanctuary-type-classes/Monad');
+  eq(Z.Monad.test(null), false);
+  eq(Z.Monad.test(''), false);
+  eq(Z.Monad.test([]), true);
+  eq(Z.Monad.test({}), false);
+});
+
+test('Foldable', function() {
+  eq(Z.Foldable['@@type'], 'sanctuary-type-classes/TypeClass');
+  eq(Z.Foldable.name, 'sanctuary-type-classes/Foldable');
+  eq(Z.Foldable.test(null), false);
+  eq(Z.Foldable.test(''), false);
+  eq(Z.Foldable.test([]), true);
+  eq(Z.Foldable.test({}), true);
+});
+
+test('Traversable', function() {
+  eq(Z.Traversable['@@type'], 'sanctuary-type-classes/TypeClass');
+  eq(Z.Traversable.name, 'sanctuary-type-classes/Traversable');
+  eq(Z.Traversable.test(null), false);
+  eq(Z.Traversable.test(''), false);
+  eq(Z.Traversable.test([]), true);
+  eq(Z.Traversable.test({}), false);
+});
+
+test('Extend', function() {
+  eq(Z.Extend['@@type'], 'sanctuary-type-classes/TypeClass');
+  eq(Z.Extend.name, 'sanctuary-type-classes/Extend');
+  eq(Z.Extend.test(null), false);
+  eq(Z.Extend.test(''), false);
+  eq(Z.Extend.test([]), true);
+  eq(Z.Extend.test({}), false);
+});
+
+test('Comonad', function() {
+  eq(Z.Comonad['@@type'], 'sanctuary-type-classes/TypeClass');
+  eq(Z.Comonad.name, 'sanctuary-type-classes/Comonad');
+  eq(Z.Comonad.test(null), false);
+  eq(Z.Comonad.test(''), false);
+  eq(Z.Comonad.test([]), false);
+  eq(Z.Comonad.test({}), false);
+  eq(Z.Comonad.test(Identity(0)), true);
+});
+
+test('toString', function() {
+  eq(Z.toString.length, 1);
+  eq(Z.toString.name, 'toString');
+
+  eq(Z.toString(null), 'null');
+  eq(Z.toString(undefined), 'undefined');
+  eq(Z.toString(false), 'false');
+  eq(Z.toString(true), 'true');
+  eq(Z.toString(new Boolean(false)), 'new Boolean(false)');
+  eq(Z.toString(new Boolean(true)), 'new Boolean(true)');
+  eq(Z.toString(0), '0');
+  eq(Z.toString(-0), '-0');
+  eq(Z.toString(NaN), 'NaN');
+  eq(Z.toString(3.14), '3.14');
+  eq(Z.toString(Infinity), 'Infinity');
+  eq(Z.toString(-Infinity), '-Infinity');
+  eq(Z.toString(new Number(0)), 'new Number(0)');
+  eq(Z.toString(new Number(-0)), 'new Number(-0)');
+  eq(Z.toString(new Number(NaN)), 'new Number(NaN)');
+  eq(Z.toString(new Number(3.14)), 'new Number(3.14)');
+  eq(Z.toString(new Number(Infinity)), 'new Number(Infinity)');
+  eq(Z.toString(new Number(-Infinity)), 'new Number(-Infinity)');
+  eq(Z.toString(new Date(0)), 'new Date("1970-01-01T00:00:00.000Z")');
+  eq(Z.toString(new Date(42)), 'new Date("1970-01-01T00:00:00.042Z")');
+  eq(Z.toString(new Date(NaN)), 'new Date(NaN)');
+  eq(Z.toString(new Date('2001-02-03T04:05:06')), 'new Date("2001-02-03T04:05:06.000Z")');
+  eq(Z.toString(/def/g), '/def/g');
+  eq(Z.toString(''), '""');
+  eq(Z.toString('abc'), '"abc"');
+  eq(Z.toString('foo "bar" baz'), '"foo \\"bar\\" baz"');
+  eq(Z.toString(new String('')), 'new String("")');
+  eq(Z.toString(new String('abc')), 'new String("abc")');
+  eq(Z.toString(new String('foo "bar" baz')), 'new String("foo \\"bar\\" baz")');
+  eq(Z.toString([]), '[]');
+  eq(Z.toString(['foo']), '["foo"]');
+  eq(Z.toString(['foo', 'bar']), '["foo", "bar"]');
+  eq(Z.toString(/x/.exec('xyz')), '["x", "index": 0, "input": "xyz"]');
+  eq(Z.toString((function() { var xs = []; xs.z = true; xs.a = true; return xs; }())), '["a": true, "z": true]');
+  eq(Z.toString(circular), '["foo", <Circular>]');
+  eq(Z.toString(args()), '(function () { return arguments; }())');
+  eq(Z.toString(args('foo')), '(function () { return arguments; }("foo"))');
+  eq(Z.toString(args('foo', 'bar')), '(function () { return arguments; }("foo", "bar"))');
+  eq(Z.toString(new Error('a')), 'new Error("a")');
+  eq(Z.toString(new TypeError('b')), 'new TypeError("b")');
+  eq(Z.toString({}), '{}');
+  eq(Z.toString({x: 1}), '{"x": 1}');
+  eq(Z.toString({x: 1, y: 2}), '{"x": 1, "y": 2}');
+  eq(Z.toString({y: 1, x: 2}), '{"x": 2, "y": 1}');
+  eq(Z.toString(node1), '{"id": 1, "rels": [{"type": "child", "value": {"id": 2, "rels": [{"type": "parent", "value": <Circular>}]}}]}');
+  eq(Z.toString(node2), '{"id": 2, "rels": [{"type": "parent", "value": {"id": 1, "rels": [{"type": "child", "value": <Circular>}]}}]}');
+  eq(Z.toString(Object.create(null)), '{}');
+  var Foo = function() {};
+  Foo.prototype = {toString: function() { return '<b>foo</b>'; }};
+  eq(Z.toString(Foo.prototype), '<b>foo</b>');
+  eq(Z.toString(new Foo()), '<b>foo</b>');
+  eq(Z.toString(Math.sqrt), 'function sqrt() { [native code] }');
+});
+
+test('equals', function() {
+  eq(Z.equals.length, 2);
+  eq(Z.equals.name, 'equals');
+
+  eq(Z.equals(null, null), true);
+  eq(Z.equals(null, undefined), false);
+  eq(Z.equals(undefined, null), false);
+  eq(Z.equals(undefined, undefined), true);
+  eq(Z.equals(false, false), true);
+  eq(Z.equals(false, true), false);
+  eq(Z.equals(true, false), false);
+  eq(Z.equals(true, true), true);
+  eq(Z.equals(new Boolean(false), new Boolean(false)), true);
+  eq(Z.equals(new Boolean(false), new Boolean(true)), false);
+  eq(Z.equals(new Boolean(true), new Boolean(false)), false);
+  eq(Z.equals(new Boolean(true), new Boolean(true)), true);
+  eq(Z.equals(false, new Boolean(false)), false);
+  eq(Z.equals(new Boolean(false), false), false);
+  eq(Z.equals(true, new Boolean(true)), false);
+  eq(Z.equals(new Boolean(true), true), false);
+  eq(Z.equals(0, 0), true);
+  eq(Z.equals(0, -0), false);
+  eq(Z.equals(-0, 0), false);
+  eq(Z.equals(-0, -0), true);
+  eq(Z.equals(NaN, NaN), true);
+  eq(Z.equals(Infinity, Infinity), true);
+  eq(Z.equals(Infinity, -Infinity), false);
+  eq(Z.equals(-Infinity, Infinity), false);
+  eq(Z.equals(-Infinity, -Infinity), true);
+  eq(Z.equals(NaN, Math.PI), false);
+  eq(Z.equals(Math.PI, NaN), false);
+  eq(Z.equals(new Number(0), new Number(0)), true);
+  eq(Z.equals(new Number(0), new Number(-0)), false);
+  eq(Z.equals(new Number(-0), new Number(0)), false);
+  eq(Z.equals(new Number(-0), new Number(-0)), true);
+  eq(Z.equals(new Number(NaN), new Number(NaN)), true);
+  eq(Z.equals(new Number(Infinity), new Number(Infinity)), true);
+  eq(Z.equals(new Number(Infinity), new Number(-Infinity)), false);
+  eq(Z.equals(new Number(-Infinity), new Number(Infinity)), false);
+  eq(Z.equals(new Number(-Infinity), new Number(-Infinity)), true);
+  eq(Z.equals(new Number(NaN), new Number(Math.PI)), false);
+  eq(Z.equals(new Number(Math.PI), new Number(NaN)), false);
+  eq(Z.equals(42, new Number(42)), false);
+  eq(Z.equals(new Number(42), 42), false);
+  eq(Z.equals(new Date(0), new Date(0)), true);
+  eq(Z.equals(new Date(0), new Date(1)), false);
+  eq(Z.equals(new Date(1), new Date(0)), false);
+  eq(Z.equals(new Date(1), new Date(1)), true);
+  eq(Z.equals(new Date(NaN), new Date(NaN)), true);
+  eq(Z.equals(/abc/, /xyz/), false);
+  eq(Z.equals(/abc/, /abc/g), false);
+  eq(Z.equals(/abc/, /abc/i), false);
+  eq(Z.equals(/abc/, /abc/m), false);
+  eq(Z.equals(/abc/, /abc/), true);
+  eq(Z.equals(/abc/g, /abc/g), true);
+  eq(Z.equals(/abc/i, /abc/i), true);
+  eq(Z.equals(/abc/m, /abc/m), true);
+  eq(Z.equals('', ''), true);
+  eq(Z.equals('abc', 'abc'), true);
+  eq(Z.equals('abc', 'xyz'), false);
+  eq(Z.equals(new String(''), new String('')), true);
+  eq(Z.equals(new String('abc'), new String('abc')), true);
+  eq(Z.equals(new String('abc'), new String('xyz')), false);
+  eq(Z.equals('abc', new String('abc')), false);
+  eq(Z.equals(new String('abc'), 'abc'), false);
+  eq(Z.equals([], []), true);
+  eq(Z.equals([1, 2], [1, 2]), true);
+  eq(Z.equals([1, 2, 3], [1, 2]), false);
+  eq(Z.equals([1, 2], [1, 2, 3]), false);
+  eq(Z.equals([1, 2], [2, 1]), false);
+  eq(Z.equals([0], [-0]), false);
+  eq(Z.equals([NaN], [NaN]), true);
+  eq(Z.equals(circular, circular), true);
+  eq(Z.equals(args(), args()), true);
+  eq(Z.equals(args(1, 2), args(1, 2)), true);
+  eq(Z.equals(args(1, 2, 3), args(1, 2)), false);
+  eq(Z.equals(args(1, 2), args(1, 2, 3)), false);
+  eq(Z.equals(args(1, 2), args(2, 1)), false);
+  eq(Z.equals(args(0), args(-0)), false);
+  eq(Z.equals(args(NaN), args(NaN)), true);
+  eq(Z.equals(new Error('abc'), new Error('abc')), true);
+  eq(Z.equals(new Error('abc'), new Error('xyz')), false);
+  eq(Z.equals(new TypeError('abc'), new TypeError('abc')), true);
+  eq(Z.equals(new TypeError('abc'), new TypeError('xyz')), false);
+  eq(Z.equals(new Error('abc'), new TypeError('abc')), false);
+  eq(Z.equals(new TypeError('abc'), new Error('abc')), false);
+  eq(Z.equals({}, {}), true);
+  eq(Z.equals({x: 1, y: 2}, {y: 2, x: 1}), true);
+  eq(Z.equals({x: 1, y: 2, z: 3}, {x: 1, y: 2}), false);
+  eq(Z.equals({x: 1, y: 2}, {x: 1, y: 2, z: 3}), false);
+  eq(Z.equals({x: 1, y: 2}, {x: 2, y: 1}), false);
+  eq(Z.equals({x: 0}, {x: -0}), false);
+  eq(Z.equals({x: NaN}, {x: NaN}), true);
+  eq(Z.equals(node1, node1), true);
+  eq(Z.equals(node2, node2), true);
+  eq(Z.equals(node1, node2), false);
+  eq(Z.equals(node2, node1), false);
+  eq(Z.equals(Math.sin, Math.sin), true);
+  eq(Z.equals(Math.sin, Math.cos), false);
+  eq(Z.equals(Identity(Identity(Identity(0))), Identity(Identity(Identity(0)))), true);
+  eq(Z.equals(Identity(Identity(Identity(0))), Identity(Identity(Identity(1)))), false);
+  eq(Z.equals({'@@type': 'my-package/Quux'}, {'@@type': 'my-package/Quux'}), false);
+});
+
+test('concat', function() {
+  eq(Z.concat.length, 2);
+  eq(Z.concat.name, 'concat');
+
+  eq(Z.concat('', ''), '');
+  eq(Z.concat('', 'abc'), 'abc');
+  eq(Z.concat('abc', ''), 'abc');
+  eq(Z.concat('abc', 'def'), 'abcdef');
+  eq(Z.concat([], []), []);
+  eq(Z.concat([], [1, 2, 3]), [1, 2, 3]);
+  eq(Z.concat([1, 2, 3], []), [1, 2, 3]);
+  eq(Z.concat([1, 2, 3], [4, 5, 6]), [1, 2, 3, 4, 5, 6]);
+  eq(Z.concat({}, {}), {});
+  eq(Z.concat({}, {x: 1, y: 2}), {x: 1, y: 2});
+  eq(Z.concat({x: 1, y: 2}, {}), {x: 1, y: 2});
+  eq(Z.concat({x: 1, y: 2}, {y: 3, z: 4}), {x: 1, y: 3, z: 4});
+  eq(Z.concat(Identity(''), Identity('')), Identity(''));
+  eq(Z.concat(Identity(''), Identity('abc')), Identity('abc'));
+  eq(Z.concat(Identity('abc'), Identity('')), Identity('abc'));
+  eq(Z.concat(Identity('abc'), Identity('def')), Identity('abcdef'));
+  eq(Z.concat(Nil, Nil), Nil);
+  eq(Z.concat(Nil, Cons(1, Cons(2, Cons(3, Nil)))), Cons(1, Cons(2, Cons(3, Nil))));
+  eq(Z.concat(Cons(1, Cons(2, Cons(3, Nil))), Nil), Cons(1, Cons(2, Cons(3, Nil))));
+  eq(Z.concat(Cons(1, Cons(2, Cons(3, Nil))), Cons(4, Cons(5, Cons(6, Nil)))), Cons(1, Cons(2, Cons(3, Cons(4, Cons(5, Cons(6, Nil)))))));
+});
+
+test('empty', function() {
+  eq(Z.empty.length, 1);
+  eq(Z.empty.name, 'empty');
+
+  eq(Z.empty(String), '');
+  eq(Z.empty(Array), []);
+  eq(Z.empty(Object), {});
+  eq(Z.empty(List), Nil);
+});
+
+test('map', function() {
+  eq(Z.map.length, 2);
+  eq(Z.map.name, 'map');
+
+  eq(Z.map(inc, []), []);
+  eq(Z.map(inc, [1, 2, 3]), [2, 3, 4]);
+  eq(Z.map(inc, {}), {});
+  eq(Z.map(inc, {x: 2, y: 4}), {x: 3, y: 5});
+  eq(Z.map(inc, length)('abc'), 4);
+  eq(Z.map(inc, Identity(42)), Identity(43));
+  eq(Z.map(inc, Nil), Nil);
+  eq(Z.map(inc, Cons(1, Cons(2, Cons(3, Nil)))), Cons(2, Cons(3, Cons(4, Nil))));
+});
+
+test('bimap', function() {
+  eq(Z.bimap.length, 3);
+  eq(Z.bimap.name, 'bimap');
+
+  eq(Z.bimap(toUpper, inc, Tuple('abc', 123)), Tuple('ABC', 124));
+});
+
+test('promap', function() {
+  eq(Z.promap.length, 3);
+  eq(Z.promap.name, 'promap');
+
+  eq(Z.promap(
+       function(xs) { return xs.reduce(function(acc, x) { return acc.concat([x.length]); }, []); },
+       square,
+       function(xs) { return xs.reduce(function(acc, x) { return acc + x; }, 0); }
+     )(['foo', 'bar', 'baz', 'quux']),
+     169);
+});
+
+test('ap', function() {
+  eq(Z.ap.length, 2);
+  eq(Z.ap.name, 'ap');
+
+  eq(Z.ap([], []), []);
+  eq(Z.ap([], [1, 2, 3]), []);
+  eq(Z.ap([inc], []), []);
+  eq(Z.ap([inc], [1, 2, 3]), [2, 3, 4]);
+  eq(Z.ap([inc, square], [1, 2, 3]), [2, 3, 4, 1, 4, 9]);
+  eq(Z.ap(pow, abs)(-1), pow(-1)(abs(-1)));
+  eq(Z.ap(pow, abs)(-2), pow(-2)(abs(-2)));
+  eq(Z.ap(pow, abs)(-3), pow(-3)(abs(-3)));
+  eq(Z.ap(Identity(inc), Identity(42)), Identity(43));
+  eq(Z.ap(Nil, Nil), Nil);
+  eq(Z.ap(Nil, Cons(1, Cons(2, Cons(3, Nil)))), Nil);
+  eq(Z.ap(Cons(inc, Nil), Nil), Nil);
+  eq(Z.ap(Cons(inc, Nil), Cons(1, Cons(2, Cons(3, Nil)))), Cons(2, Cons(3, Cons(4, Nil))));
+  eq(Z.ap(Cons(inc, Cons(square, Nil)), Cons(1, Cons(2, Cons(3, Nil)))), Cons(2, Cons(3, Cons(4, Cons(1, Cons(4, Cons(9, Nil)))))));
+});
+
+test('of', function() {
+  eq(Z.of.length, 2);
+  eq(Z.of.name, 'of');
+
+  eq(Z.of(Array, 42), [42]);
+  eq(Z.of(Function, 42)(null), 42);
+  eq(Z.of(Identity, 42), Identity(42));
+  eq(Z.of(List, 42), Cons(42, Nil));
+});
+
+test('chain', function() {
+  eq(Z.chain.length, 2);
+  eq(Z.chain.name, 'chain');
+
+  eq(Z.chain(duplicate, []), []);
+  eq(Z.chain(duplicate, [1, 2, 3]), [1, 1, 2, 2, 3, 3]);
+  eq(Z.chain(identity, [[1, 2], [3, 4], [5, 6]]), [1, 2, 3, 4, 5, 6]);
+  eq(Z.chain(repeat, abs)(-1), [-1]);
+  eq(Z.chain(repeat, abs)(-2), [-2, -2]);
+  eq(Z.chain(repeat, abs)(-3), [-3, -3, -3]);
+  eq(Z.chain(identInc, Identity(42)), Identity(43));
+  eq(Z.chain(identity, Identity(Identity(0))), Identity(0));
+});
+
+test('chainRec', function() {
+  eq(Z.chainRec.length, 3);
+  eq(Z.chainRec.name, 'chainRec');
+
+  var count = 0;
+
+  //  squash :: (Any -> a, Any -> a, Any) -> Array b
+  var squash = function(next, done, x) {
+    if (Array.isArray(x)) return x.map(next);
+    count += 1;
+    return [done(x)];
+  };
+
+  eq(Z.chainRec(Array, squash, [1, [[2, 3], 4], 5]), [1, 2, 3, 4, 5]);
+  eq(count, 5);
+
+  eq(Z.chainRec(Array, function(next, done, n) { return n === 0 ? [done('DONE')] : [next(n - 1)]; }, 100000), ['DONE']);
+});
+
+test('filter', function() {
+  eq(Z.filter.length, 2);
+  eq(Z.filter.name, 'filter');
+
+  eq(Z.filter(odd, []), []);
+  eq(Z.filter(odd, [1, 2, 3, 4, 5]), [1, 3, 5]);
+  eq(Z.filter(odd, Nil), Nil);
+  eq(Z.filter(odd, Cons(1, Cons(2, Cons(3, Cons(4, Cons(5, Nil)))))), Cons(1, Cons(3, Cons(5, Nil))));
+});
+
+test('filterM', function() {
+  eq(Z.filterM.length, 2);
+  eq(Z.filterM.name, 'filterM');
+
+  eq(Z.filterM(odd, []), []);
+  eq(Z.filterM(odd, [1, 2, 3, 4, 5]), [1, 3, 5]);
+  eq(Z.filterM(odd, Nil), Nil);
+  eq(Z.filterM(odd, Cons(1, Cons(2, Cons(3, Cons(4, Cons(5, Nil)))))), Cons(1, Cons(3, Cons(5, Nil))));
+});
+
+test('reduce', function() {
+  eq(Z.reduce.length, 3);
+  eq(Z.reduce.name, 'reduce');
+
+  eq(Z.reduce(Z.concat, 'x', []), 'x');
+  eq(Z.reduce(Z.concat, 'x', ['a', 'b', 'c']), 'xabc');
+  eq(Z.reduce(add, 0, {}), 0);
+  eq(Z.reduce(add, 0, {a: 1, b: 2, c: 3, d: 4, e: 5}), 15);
+  eq(Z.reduce(Z.concat, 'x', Nil), 'x');
+  eq(Z.reduce(Z.concat, 'x', Cons('a', Cons('b', Cons('c', Nil)))), 'xabc');
+});
+
+test('traverse', function() {
+  eq(Z.traverse.length, 3);
+  eq(Z.traverse.name, 'traverse');
+
+  eq(Z.traverse(Array$of, identity, []), [[]]);
+  eq(Z.traverse(Array$of, identity, [[1], [2], [3]]), [[1, 2, 3]]);
+  eq(Z.traverse(Array$of, identity, [[1, 2, 3], [4, 5]]), [[1, 4], [1, 5], [2, 4], [2, 5], [3, 4], [3, 5]]);
+  eq(Z.traverse(Array$of, identity, repeat(6)(range(10))).length, Math.pow(10, 6));
+  eq(Z.traverse(Identity, identInc, []), Identity([]));
+  eq(Z.traverse(Identity, identInc, [1, 2, 3]), Identity([2, 3, 4]));
+  eq(Z.traverse(Identity, identInc, Nil), Identity(Nil));
+  eq(Z.traverse(Identity, identInc, Cons(1, Cons(2, Cons(3, Nil)))), Identity(Cons(2, Cons(3, Cons(4, Nil)))));
+});
+
+test('sequence', function() {
+  eq(Z.sequence.length, 2);
+  eq(Z.sequence.name, 'sequence');
+
+  eq(Z.sequence(Identity, []), Identity([]));
+  eq(Z.sequence(Identity, [Identity(1), Identity(2), Identity(3)]), Identity([1, 2, 3]));
+  eq(Z.sequence(Array$of, Identity([])), []);
+  eq(Z.sequence(Array$of, Identity([1, 2, 3])), [Identity(1), Identity(2), Identity(3)]);
+  eq(Z.sequence(Identity, Nil), Identity(Nil));
+  eq(Z.sequence(Identity, Cons(Identity(1), Cons(Identity(2), Cons(Identity(3), Nil)))), Identity(Cons(1, Cons(2, Cons(3, Nil)))));
+  eq(Z.sequence(List$of, Identity(Nil)), Nil);
+  eq(Z.sequence(List$of, Identity(Cons(1, Cons(2, Cons(3, Nil))))), Cons(Identity(1), Cons(Identity(2), Cons(Identity(3), Nil))));
+});
+
+test('extend', function() {
+  eq(Z.extend.length, 2);
+  eq(Z.extend.name, 'extend');
+
+  eq(Z.extend(length, []), [0]);
+  eq(Z.extend(length, [1, 2, 3]), [3]);
+  eq(Z.extend(function(id) { return Z.reduce(add, 1, id); }, Identity(42)), Identity(43));
+});
+
+test('extract', function() {
+  eq(Z.extract.length, 1);
+  eq(Z.extract.name, 'extract');
+
+  eq(Z.extract(Identity(42)), 42);
+});


### PR DESCRIPTION
This pull request defines the following:

  - `Z.TypeClass :: (String, Array TypeClass, a -> Boolean) -> TypeClass`
  - `Z.Setoid :: TypeClass`
  - `Z.Semigroup :: TypeClass`
  - `Z.Monoid :: TypeClass`
  - `Z.Functor :: TypeClass`
  - `Z.Bifunctor :: TypeClass`
  - `Z.Profunctor :: TypeClass`
  - `Z.Apply :: TypeClass`
  - `Z.Applicative :: TypeClass`
  - `Z.Chain :: TypeClass`
  - `Z.ChainRec :: TypeClass`
  - `Z.Monad :: TypeClass`
  - `Z.Foldable :: TypeClass`
  - `Z.Traversable :: TypeClass`
  - `Z.Extend :: TypeClass`
  - `Z.Comonad :: TypeClass`
  - `Z.toString :: Showable a => a -> String`
  - `Z.equals :: (a, b) -> Boolean`
  - `Z.concat :: Semigroup a => (a, a) -> a`
  - `Z.empty :: Monoid m => TypeRep m -> m`
  - `Z.map :: Functor f => (a -> b, f a) -> f b`
  - `Z.bimap :: Bifunctor f => (a -> b, c -> d, f a c) -> f b d`
  - `Z.promap :: Profunctor p => (a -> b, c -> d, p b c) -> p a d`
  - `Z.ap :: Apply f => (f (a -> b), f a) -> f b`
  - `Z.of :: Applicative f => (TypeRep f, a) -> f a`
  - `Z.chain :: Chain m => (a -> m b, m a) -> m b`
  - `Z.chainRec :: ChainRec m => (TypeRep m, (a -> c, b -> c, a) -> m c, a) -> m b`
  - `Z.filter :: (Applicative f, Foldable f, Monoid (f a)) => (a -> Boolean, f a) -> f a`
  - `Z.filterM :: (Monad m, Monoid (m a)) => (a -> Boolean, m a) -> m a`
  - `Z.reduce :: Foldable f => ((b, a) -> b, b, f a) -> b`
  - `Z.traverse :: (Applicative f, Traversable t) => (a -> f a, b -> f c, t b) -> f (t c)`
  - `Z.sequence :: (Applicative f, Traversable t) => (a -> f a, t (f b)) -> f (t b)`
  - `Z.extend :: Extend w => (w a -> b, w a) -> w b`
  - `Z.extract :: Comonad w => w a -> a`

---

Original description:

> This pull request is not yet ready to merge, but it's *well* past my bedtime!
>
> In sanctuary-js/sanctuary-def#62 @kedashoe suggested creating a repository for type classes. Having all the Fantasy Land type classes neatly defined in one place sounded great to me, so I've since spent some time making it happen.
>
> While writing the predicates I realized we want Array to be considered a Chain (among other type classes) but `Array#chain` is not defined. This presents us with three options:
>
>   - force Sanctuary to provide its *own* Chain type class when we define `S.chain`;
>
>   - claim that Array satisfies the requirements of Chain and hope that somehow it does (because libraries such as Sanctuary add logic to handle the missing method); or
>
>   - define `chain` for Array, and provide a `chain` function which makes use of this definition.
>
> The last option seems best to me. We'll have all the definitions of Fantasy Land methods for built-in types in one place rather than scattered through a dozen or so files in Ramda. :)
>
> Note that while the methods are in place, I've yet to define the functions to wrap them. We should avoid invoking methods directly so we don't invoke missing methods such as `Array#chain`, and to ensure we use our lawful `map` rather than `Array#map`.
