### PR TITLE
derive ‘lift2’ and ‘lift3’ from ‘map’ and ‘ap’

### DIFF
--- a/index.js
+++ b/index.js
@@ -1037,6 +1037,46 @@
     return Apply.methods.ap(applyX)(applyF);
   };
 
+  //# lift2 :: Apply f => (a -> b -> c, f a, f b) -> f c
+  //.
+  //. Lifts `a -> b -> c` to `Apply f => f a -> f b -> f c` and returns the
+  //. result of applying this to the given arguments.
+  //.
+  //. This function is derived from [`map`](#map) and [`ap`](#ap).
+  //.
+  //. See also [`lift3`](#lift3).
+  //.
+  //. ```javascript
+  //. > lift2(x => y => Math.pow(x, y), [10], [1, 2, 3])
+  //. [10, 100, 1000]
+  //.
+  //. > lift2(x => y => Math.pow(x, y), Identity(10), Identity(3))
+  //. Identity(1000)
+  //. ```
+  var lift2 = function lift2(f, x, y) {
+    return ap(map(f, x), y);
+  };
+
+  //# lift3 :: Apply f => (a -> b -> c -> d, f a, f b, f c) -> f d
+  //.
+  //. Lifts `a -> b -> c -> d` to `Apply f => f a -> f b -> f c -> f d` and
+  //. returns the result of applying this to the given arguments.
+  //.
+  //. This function is derived from [`map`](#map) and [`ap`](#ap).
+  //.
+  //. See also [`lift2`](#lift2).
+  //.
+  //. ```javascript
+  //. > lift3(x => y => z => x + z + y, ['<'], ['>'], ['foo', 'bar', 'baz'])
+  //. ['<foo>', '<bar>', '<baz>']
+  //.
+  //. > lift3(x => y => z => x + z + y, Identity('<'), Identity('>'), Identity('baz'))
+  //. Identity('<baz>')
+  //. ```
+  var lift3 = function lift3(f, x, y, z) {
+    return ap(ap(map(f, x), y), z);
+  };
+
   //# of :: Applicative f => (TypeRep f, a) -> f a
   //.
   //. Function wrapper for [`fantasy-land/of`][].
@@ -1252,6 +1292,8 @@
     bimap: bimap,
     promap: promap,
     ap: ap,
+    lift2: lift2,
+    lift3: lift3,
     of: of,
     chain: chain,
     chainRec: chainRec,

--- a/test/index.js
+++ b/test/index.js
@@ -128,6 +128,18 @@ var toUpper = function(s) {
   return s.toUpperCase();
 };
 
+//  wrap :: String -> String -> String -> String
+var wrap = function(before) {
+  eq(arguments.length, 1);
+  return function(after) {
+    eq(arguments.length, 1);
+    return function(s) {
+      eq(arguments.length, 1);
+      return before + s + after;
+    };
+  };
+};
+
 
 test('TypeClass', function() {
   eq(typeof Z.TypeClass, 'function');
@@ -551,6 +563,22 @@ test('ap', function() {
   eq(Z.ap(Cons(inc, Nil), Nil), Nil);
   eq(Z.ap(Cons(inc, Nil), Cons(1, Cons(2, Cons(3, Nil)))), Cons(2, Cons(3, Cons(4, Nil))));
   eq(Z.ap(Cons(inc, Cons(square, Nil)), Cons(1, Cons(2, Cons(3, Nil)))), Cons(2, Cons(3, Cons(4, Cons(1, Cons(4, Cons(9, Nil)))))));
+});
+
+test('lift2', function() {
+  eq(Z.lift2.length, 3);
+  eq(Z.lift2.name, 'lift2');
+
+  eq(Z.lift2(pow, [10], [1, 2, 3]), [10, 100, 1000]);
+  eq(Z.lift2(pow, Identity(10), Identity(3)), Identity(1000));
+});
+
+test('lift3', function() {
+  eq(Z.lift3.length, 4);
+  eq(Z.lift3.name, 'lift3');
+
+  eq(Z.lift3(wrap, ['<'], ['>'], ['foo', 'bar', 'baz']), ['<foo>', '<bar>', '<baz>']);
+  eq(Z.lift3(wrap, Identity('<'), Identity('>'), Identity('baz')), Identity('<baz>'));
 });
 
 test('of', function() {


### PR DESCRIPTION
Sanctuary provides [`S.lift`][1], [`S.lift2`][2], and [`S.lift3`][3]. `lift` is an alias for `map`, but it makes sense to define `lift2` and `lift3` here rather than in Sanctuary. `S.lift2` and `S.lift3` can then simply be curried equivalents of `Z.lift2` and `Z.lift3`.


[1]: https://sanctuary.js.org/#lift
[2]: https://sanctuary.js.org/#lift2
[3]: https://sanctuary.js.org/#lift3
