### PR TITLE
remove superfluous equality check in ‘equals’

### DIFF
--- a/index.js
+++ b/index.js
@@ -932,9 +932,6 @@
   //. false
   //. ```
   var equals = (function() {
-    //  eq :: Setoid a => a -> a -> Boolean
-    var eq = Setoid.methods.equals;
-
     //  $seen :: Array Any
     var $seen = [];
 
@@ -942,7 +939,7 @@
     var equal = function(x, y) {
       $seen.push(x, y);
       try {
-        return Setoid.test(x) && Setoid.test(y) && eq(x)(y) && eq(y)(x);
+        return Setoid.test(x) && Setoid.test(y) && Setoid.methods.equals(x)(y);
       } finally {
         $seen.splice(-2, 2);
       }


### PR DESCRIPTION
Closes #15

Commit message:

> The [Setoid][1] type class requires
>
>     x `equals` y = y `equals` x
>
> so the second check is superfluous.


[1]: https://github.com/fantasyland/fantasy-land#setoid
