### PR TITLE
lint: replace magical comments with command-line arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,12 @@ lint:
 	  -- index.js
 	$(ESLINT) \
 	  --env node \
-	  -- $(PREDOCTEST) $(TEST)
+	  -- $(PREDOCTEST)
+	$(ESLINT) \
+	  --env node \
+	  --global test \
+	  --rule 'max-len: [off]' \
+	  -- $(TEST)
 	$(REMEMBER_BOWER) $(shell pwd)
 	@echo 'Checking for missing link definitions...'
 	grep -o '\[[^]]*\]\[[^]]*\]' index.js \

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-/* eslint-env mocha */
-/* eslint max-len: "off" */
-
 var type = require('sanctuary-type-identifiers');
 
 var Z = require('..');


### PR DESCRIPTION
We use command-line arguments to tweak ESLint settings in other Sanctuary projects. We should do the same here for the sake of consistency.
