### PR TITLE
circumvent Safari bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1247,8 +1247,8 @@
   //. > chain(n => s => s.slice(0, n), s => Math.ceil(s.length / 2))('Haskell')
   //. 'Hask'
   //. ```
-  function chain(f, chain) {
-    return Chain.methods.chain(chain)(f);
+  function chain(f, chain_) {
+    return Chain.methods.chain(chain_)(f);
   }
 
   //# join :: Chain m => m (m a) -> m a
@@ -1447,8 +1447,8 @@
   //. > extend(xs => xs.length, ['foo', 'bar', 'baz', 'quux'])
   //. [4]
   //. ```
-  function extend(f, extend) {
-    return Extend.methods.extend(extend)(f);
+  function extend(f, extend_) {
+    return Extend.methods.extend(extend_)(f);
   }
 
   //# extract :: Comonad w => w a -> a


### PR DESCRIPTION
In strict mode `function x(x) {}` is a syntax error in certain Safari versions (mishoo/UglifyJS2#179). Safari 10.0.2 does not have this bug, but the Sanctuary test suite runs against Safari 8 as well. Score another point for @Shard; real browser tests are proving very useful!

I'm targeting a temporary `v1` branch. After merging this pull request I'll release v1.3.1. I'll then merge `v1` into `master`, release v2.0.1, then delete `v1`.
