### PR TITLE
fix incorrect use of sequence in example

### DIFF
--- a/index.js
+++ b/index.js
@@ -1422,7 +1422,7 @@
   //. This function is derived from [`traverse`](#traverse).
   //.
   //. ```javascript
-  //. > sequence(x => [x], Identity([1, 2, 3]))
+  //. > sequence(Array, Identity([1, 2, 3]))
   //. [Identity(1), Identity(2), Identity(3)]
   //.
   //. > sequence(Identity, [Identity(1), Identity(2), Identity(3)])


### PR DESCRIPTION
sequence should take `TypeRep` and in example we are passing a function