### PR TITLE
replace Monoid dependency with Alternative dependency for ‘filterM’

### DIFF
--- a/index.js
+++ b/index.js
@@ -1333,8 +1333,8 @@
   //.
   //. Filters its second argument in accordance with the given predicate.
   //.
-  //. This function is derived from [`empty`](#empty), [`of`](#of), and
-  //. [`reduce`](#reduce).
+  //. This function is derived from [`concat`](#concat), [`empty`](#empty),
+  //. [`of`](#of), and [`reduce`](#reduce).
   //.
   //. See also [`filterM`](#filterM).
   //.
@@ -1352,12 +1352,12 @@
                   m);
   }
 
-  //# filterM :: (Monad m, Monoid (m a)) => (a -> Boolean, m a) -> m a
+  //# filterM :: (Alternative m, Monad m) => (a -> Boolean, m a) -> m a
   //.
   //. Filters its second argument in accordance with the given predicate.
   //.
-  //. This function is derived from [`empty`](#empty), [`of`](#of), and
-  //. [`chain`](#chain).
+  //. This function is derived from [`of`](#of), [`chain`](#chain), and
+  //. [`zero`](#zero).
   //.
   //. See also [`filter`](#filter).
   //.
@@ -1367,11 +1367,20 @@
   //.
   //. > filterM(x => x % 2 == 1, Cons(1, Cons(2, Cons(3, Nil))))
   //. Cons(1, Cons(3, Nil))
+  //.
+  //. > filterM(x => x % 2 == 1, Nothing)
+  //. Nothing
+  //.
+  //. > filterM(x => x % 2 == 1, Just(0))
+  //. Nothing
+  //.
+  //. > filterM(x => x % 2 == 1, Just(1))
+  //. Just(1)
   //. ```
   function filterM(pred, m) {
     var M = m.constructor;
-    var e = empty(M);
-    return chain(function(x) { return pred(x) ? of(M, x) : e; }, m);
+    var z = zero(M);
+    return chain(function(x) { return pred(x) ? of(M, x) : z; }, m);
   }
 
   //# alt :: Alt f => (f a, f a) -> f a

--- a/test/List.js
+++ b/test/List.js
@@ -35,6 +35,8 @@ List[FL.empty] = function() { return Nil; };
 
 List[FL.of] = function(x) { return Cons(x, Nil); };
 
+List[FL.zero] = List[FL.empty];
+
 List.prototype[FL.equals] = function(other) {
   return this.tag === 'Nil' ?
     other.tag === 'Nil' :
@@ -66,6 +68,8 @@ List.prototype[FL.chain] = function(f) {
     Nil :
     Z.concat(f(this.head), Z.chain(f, this.tail));
 };
+
+List.prototype[FL.alt] = List.prototype[FL.concat];
 
 List.prototype[FL.reduce] = function(f, x) {
   return this.tag === 'Nil' ?

--- a/test/Maybe.js
+++ b/test/Maybe.js
@@ -19,9 +19,13 @@ Maybe['@@type'] = 'sanctuary-type-classes/Maybe';
 
 Maybe.Nothing = new _Maybe('Nothing');
 
-Maybe[FL.of] = Maybe.Just = function(x) { return new _Maybe('Just', x); };
+Maybe.Just = function(x) { return new _Maybe('Just', x); };
 
-Maybe[FL.empty] = Maybe[FL.zero] = function() { return Maybe.Nothing; };
+Maybe[FL.empty] = function() { return Maybe.Nothing; };
+
+Maybe[FL.of] = Maybe.Just;
+
+Maybe[FL.zero] = Maybe[FL.empty];
 
 Maybe.prototype[FL.equals] = function(other) {
   return this.isNothing ? other.isNothing
@@ -30,6 +34,10 @@ Maybe.prototype[FL.equals] = function(other) {
 
 Maybe.prototype[FL.map] = function(f) {
   return this.isJust ? Maybe.Just(f(this.value)) : Maybe.Nothing;
+};
+
+Maybe.prototype[FL.chain] = function(f) {
+  return this.isJust ? f(this.value) : Maybe.Nothing;
 };
 
 Maybe.prototype[FL.alt] = function(other) {

--- a/test/index.js
+++ b/test/index.js
@@ -733,6 +733,9 @@ test('filterM', function() {
   eq(Z.filterM(odd, [1, 2, 3, 4, 5]), [1, 3, 5]);
   eq(Z.filterM(odd, Nil), Nil);
   eq(Z.filterM(odd, Cons(1, Cons(2, Cons(3, Cons(4, Cons(5, Nil)))))), Cons(1, Cons(3, Cons(5, Nil))));
+  eq(Z.filterM(odd, Nothing), Nothing);
+  eq(Z.filterM(odd, Just(0)), Nothing);
+  eq(Z.filterM(odd, Just(1)), Just(1));
 });
 
 test('alt', function() {


### PR DESCRIPTION
:warning: This is a breaking change.

It became apparent in sanctuary-js/sanctuary#359 that `Z.filterM(odd, Just(4))` is invalid due to the `Monoid (m a)` constraint. `Just(4)` cannot satisfy this constraint as it cannot satisfy the requirements of Semigroup. `Just(4)` can, though, satisfy the requirements of Alternative.

This will allow `S.filterM` to operate on values of type `Maybe a` even with type checking enabled.
