### PR TITLE
getBoundMethod now checks whether or not a Constructor is a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,14 +196,25 @@
     return _funcPath(false, path, implementations);
   }
 
+  //  functionName :: Function -> String
+  var functionName = 'name' in function f() {} ?
+    function functionName(f) { return f.name; } :
+    /* istanbul ignore next */
+    function functionName(f) {
+      var match = /function (\w*)/.exec(f);
+      return match == null ? '' : match[1];
+    };
+
   //  $ :: (String, Array TypeClass, StrMap (Array Location)) -> TypeClass
   function $(_name, dependencies, requirements) {
     function getBoundMethod(_name) {
       var name = 'fantasy-land/' + _name;
       return requirements[_name] === Constructor ?
         function(typeRep) {
-          return funcPath([name], typeRep) ||
-                 implPath([/function (\w*)/.exec(typeRep)[1], name]);
+          var f = funcPath([name], typeRep);
+          return f == null && typeof typeRep === 'function' ?
+            implPath([functionName(typeRep), name]) :
+            f;
         } :
         function(x) {
           var isPrototype = x != null &&

--- a/test/Maybe.js
+++ b/test/Maybe.js
@@ -19,9 +19,9 @@ Maybe['@@type'] = 'sanctuary-type-classes/Maybe';
 
 Maybe.Nothing = new _Maybe('Nothing');
 
-Maybe.Just = function(x) { return new _Maybe('Just', x); };
+Maybe[FL.of] = Maybe.Just = function(x) { return new _Maybe('Just', x); };
 
-Maybe[FL.zero] = function() { return Maybe.Nothing; };
+Maybe[FL.empty] = Maybe[FL.zero] = function() { return Maybe.Nothing; };
 
 Maybe.prototype[FL.equals] = function(other) {
   return this.isNothing ? other.isNothing

--- a/test/index.js
+++ b/test/index.js
@@ -546,6 +546,7 @@ test('empty', function() {
   eq(Z.empty(Array), []);
   eq(Z.empty(Object), {});
   eq(Z.empty(List), Nil);
+  eq(Z.empty(Maybe), Nothing);
 });
 
 test('map', function() {
@@ -647,6 +648,7 @@ test('of', function() {
   eq(Z.of(Function, 42)(null), 42);
   eq(Z.of(Identity, 42), Identity(42));
   eq(Z.of(List, 42), Cons(42, Nil));
+  eq(Z.of(Maybe, 42), Just(42));
 });
 
 test('chain', function() {


### PR DESCRIPTION
See https://github.com/sanctuary-js/sanctuary/issues/361

I added a `throws` function to check that the proper exception was being thrown. I also updated `test/Maybe` to implement `of` and `empty` as its constructor is not a function and is thus a good candidate for testing this code path.