### PR TITLE
Add missing instances (mostly `Ord`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -518,7 +518,9 @@
 
   //  Boolean$prototype$equals :: Boolean ~> Boolean -> Boolean
   function Boolean$prototype$equals(other) {
-    return typeof other === typeof this && other.valueOf() === this.valueOf();
+    return typeof this === 'object' ?
+      equals(this.valueOf(), other.valueOf()) :
+      this === other;
   }
 
   //  Number$prototype$toString :: Number ~> () -> String
@@ -530,11 +532,9 @@
 
   //  Number$prototype$equals :: Number ~> Number -> Boolean
   function Number$prototype$equals(other) {
-    return typeof other === 'object' ?
-      typeof this === 'object' &&
-        equals(this.valueOf(), other.valueOf()) :
-      isNaN(other) && isNaN(this) ||
-        other === this && 1 / other === 1 / this;
+    return typeof this === 'object' ?
+      equals(this.valueOf(), other.valueOf()) :
+      isNaN(this) && isNaN(other) || this === other && 1 / this === 1 / other;
   }
 
   //  Date$prototype$toString :: Date ~> () -> String
@@ -580,7 +580,9 @@
 
   //  String$prototype$equals :: String ~> String -> Boolean
   function String$prototype$equals(other) {
-    return typeof other === typeof this && other.valueOf() === this.valueOf();
+    return typeof this === 'object' ?
+      equals(this.valueOf(), other.valueOf()) :
+      this === other;
   }
 
   //  String$prototype$concat :: String ~> String -> String
@@ -1016,9 +1018,7 @@
     var $pairs = [];
 
     return function equals(x, y) {
-      if (type(x) !== type(y)) {
-        return false;
-      }
+      if (typeof x !== typeof y || type(x) !== type(y)) return false;
 
       //  This algorithm for comparing circular data structures was
       //  suggested in <http://stackoverflow.com/a/40622794/312785>.

--- a/index.js
+++ b/index.js
@@ -255,6 +255,16 @@
   //. ```
   var Setoid = $('Setoid', [], {equals: Value});
 
+  //# Ord :: TypeClass
+  //.
+  //. `TypeClass` value for [Ord][].
+  //.
+  //. ```javascript
+  //. > Ord.test(null)
+  //. true
+  //. ```
+  var Ord = $('Ord', [Setoid], {lte: Value});
+
   //# Semigroup :: TypeClass
   //.
   //. `TypeClass` value for [Semigroup][].
@@ -499,6 +509,11 @@
     return true;
   }
 
+  //  Null$prototype$lte :: Null ~> Null -> Boolean
+  function Null$prototype$lte(other) {
+    return true;
+  }
+
   //  Undefined$prototype$toString :: Undefined ~> () -> String
   function Undefined$prototype$toString() {
     return 'undefined';
@@ -506,6 +521,11 @@
 
   //  Undefined$prototype$equals :: Undefined ~> Undefined -> Boolean
   function Undefined$prototype$equals(other) {
+    return true;
+  }
+
+  //  Undefined$prototype$lte :: Undefined ~> Undefined -> Boolean
+  function Undefined$prototype$lte(other) {
     return true;
   }
 
@@ -523,6 +543,13 @@
       this === other;
   }
 
+  //  Boolean$prototype$lte :: Boolean ~> Boolean -> Boolean
+  function Boolean$prototype$lte(other) {
+    return typeof this === 'object' ?
+      lte(this.valueOf(), other.valueOf()) :
+      this <= other;
+  }
+
   //  Number$prototype$toString :: Number ~> () -> String
   function Number$prototype$toString() {
     return typeof this === 'object' ?
@@ -534,7 +561,14 @@
   function Number$prototype$equals(other) {
     return typeof this === 'object' ?
       equals(this.valueOf(), other.valueOf()) :
-      isNaN(this) && isNaN(other) || this === other && 1 / this === 1 / other;
+      isNaN(this) && isNaN(other) || this === other;
+  }
+
+  //  Number$prototype$lte :: Number ~> Number -> Boolean
+  function Number$prototype$lte(other) {
+    return typeof this === 'object' ?
+      lte(this.valueOf(), other.valueOf()) :
+      isNaN(other) && isNaN(this) || this <= other;
   }
 
   //  Date$prototype$toString :: Date ~> () -> String
@@ -546,6 +580,11 @@
   //  Date$prototype$equals :: Date ~> Date -> Boolean
   function Date$prototype$equals(other) {
     return equals(this.valueOf(), other.valueOf());
+  }
+
+  //  Date$prototype$lte :: Date ~> Date -> Boolean
+  function Date$prototype$lte(other) {
+    return lte(this.valueOf(), other.valueOf());
   }
 
   //  RegExp$prototype$equals :: RegExp ~> RegExp -> Boolean
@@ -583,6 +622,13 @@
     return typeof this === 'object' ?
       equals(this.valueOf(), other.valueOf()) :
       this === other;
+  }
+
+  //  String$prototype$lte :: String ~> String -> Boolean
+  function String$prototype$lte(other) {
+    return typeof this === 'object' ?
+      lte(this.valueOf(), other.valueOf()) :
+      this <= other;
   }
 
   //  String$prototype$concat :: String ~> String -> String
@@ -639,6 +685,19 @@
     for (var idx = 0; idx < this.length; idx += 1) {
       if (!equals(this[idx], other[idx])) return false;
     }
+    return true;
+  }
+
+  //  Array$prototype$lte :: Array a ~> Array a -> Boolean
+  function Array$prototype$lte(other) {
+    for (var idx = 0; idx < this.length; idx += 1) {
+      if (idx >= other.length) return false;
+
+      if (!equals(this[idx], other[idx])) {
+        return lte(this[idx], other[idx]);
+      }
+    }
+
     return true;
   }
 
@@ -709,6 +768,11 @@
   //  Arguments$prototype$equals :: Arguments ~> Arguments -> Boolean
   function Arguments$prototype$equals(other) {
     return Array$prototype$equals.call(this, other);
+  }
+
+  //  Arguments$prototype$lte :: Arguments ~> Arguments -> Boolean
+  function Arguments$prototype$lte(other) {
+    return Array$prototype$lte.call(this, other);
   }
 
   //  Error$prototype$toString :: Error ~> () -> String
@@ -828,6 +892,18 @@
     return function(x) { return f(chain(x))(x); };
   }
 
+  //  Function$prototype$alt :: Alt a => (x -> a) ~> (x -> a) -> x -> a
+  function Function$prototype$alt(f) {
+    var alt_ = this;
+    return function(x) { return alt(alt_(x), f(x)); };
+  }
+
+  //  Function$prototype$concat :: Semigroup a => (x -> a) ~> (x -> a) -> x -> a
+  function Function$prototype$concat(f) {
+    var semigroup = this;
+    return function(x) { return concat(semigroup(x), f(x)); };
+  }
+
   //  Function$prototype$contramap :: (b -> c) ~> (a -> b) -> (a -> c)
   function Function$prototype$contramap(f) {
     var contravariant = this;
@@ -839,31 +915,36 @@
     Null: {
       prototype: {
         toString:                   Null$prototype$toString,
-        'fantasy-land/equals':      Null$prototype$equals
+        'fantasy-land/equals':      Null$prototype$equals,
+        'fantasy-land/lte':         Null$prototype$lte
       }
     },
     Undefined: {
       prototype: {
         toString:                   Undefined$prototype$toString,
-        'fantasy-land/equals':      Undefined$prototype$equals
+        'fantasy-land/equals':      Undefined$prototype$equals,
+        'fantasy-land/lte':         Undefined$prototype$lte
       }
     },
     Boolean: {
       prototype: {
         toString:                   Boolean$prototype$toString,
-        'fantasy-land/equals':      Boolean$prototype$equals
+        'fantasy-land/equals':      Boolean$prototype$equals,
+        'fantasy-land/lte':         Boolean$prototype$lte
       }
     },
     Number: {
       prototype: {
         toString:                   Number$prototype$toString,
-        'fantasy-land/equals':      Number$prototype$equals
+        'fantasy-land/equals':      Number$prototype$equals,
+        'fantasy-land/lte':         Number$prototype$lte
       }
     },
     Date: {
       prototype: {
         toString:                   Date$prototype$toString,
-        'fantasy-land/equals':      Date$prototype$equals
+        'fantasy-land/equals':      Date$prototype$equals,
+        'fantasy-land/lte':         Date$prototype$lte
       }
     },
     RegExp: {
@@ -876,6 +957,7 @@
       prototype: {
         toString:                   String$prototype$toString,
         'fantasy-land/equals':      String$prototype$equals,
+        'fantasy-land/lte':         String$prototype$lte,
         'fantasy-land/concat':      String$prototype$concat
       }
     },
@@ -887,6 +969,7 @@
       prototype: {
         toString:                   Array$prototype$toString,
         'fantasy-land/equals':      Array$prototype$equals,
+        'fantasy-land/lte':         Array$prototype$lte,
         'fantasy-land/concat':      Array$prototype$concat,
         'fantasy-land/map':         Array$prototype$map,
         'fantasy-land/ap':          Array$prototype$ap,
@@ -900,7 +983,8 @@
     Arguments: {
       prototype: {
         toString:                   Arguments$prototype$toString,
-        'fantasy-land/equals':      Arguments$prototype$equals
+        'fantasy-land/equals':      Arguments$prototype$equals,
+        'fantasy-land/lte':         Arguments$prototype$lte
       }
     },
     Error: {
@@ -926,6 +1010,8 @@
       'fantasy-land/of':            Function$of,
       'fantasy-land/chainRec':      Function$chainRec,
       prototype: {
+        'fantasy-land/alt':         Function$prototype$alt,
+        'fantasy-land/concat':      Function$prototype$concat,
         'fantasy-land/equals':      Function$prototype$equals,
         'fantasy-land/map':         Function$prototype$map,
         'fantasy-land/promap':      Function$prototype$promap,
@@ -1002,7 +1088,7 @@
   //.
   //. ```javascript
   //. > equals(0, -0)
-  //. false
+  //. true
   //.
   //. > equals(NaN, NaN)
   //. true
@@ -1032,6 +1118,37 @@
       } finally {
         $pairs.pop();
       }
+    };
+  }());
+
+  //# lte :: (a, b) -> Boolean
+  //.
+  //. Returns `true` if its arguments are of the same type and the first be
+  //. less than or equal to the second according to the type's
+  //. [`fantasy-land/equals`][] method; `false` otherwise.
+  //.
+  //. `fantasy-land/lte` implementations are provided for the following
+  //. built-in types: Null, Undefined, Boolean, Number, Date, String,
+  //. Array, Arguments, and Function.
+  //.
+  //. ```javascript
+  //. > lte(0, -0)
+  //. true
+  //.
+  //. > lte(NaN, NaN)
+  //. true
+  //.
+  //. > lte(Cons('foo', Nil), Cons('foo', Cons('bar', Nil)))
+  //. true
+  //.
+  //. > lte(Cons('foo', Cons('bar', Nil)), Cons('bar', Cons('foo', Nil)))
+  //. false
+  //. ```
+  var lte = (function() {
+    return function lte(x, y) {
+      if (typeof x !== typeof y || type(x) !== type(y)) return false;
+
+      return Ord.test(x) && Ord.test(y) && Ord.methods.lte(x)(y);
     };
   }());
 
@@ -1528,6 +1645,7 @@
   return {
     TypeClass: TypeClass,
     Setoid: Setoid,
+    Ord: Ord,
     Semigroup: Semigroup,
     Monoid: Monoid,
     Functor: Functor,
@@ -1548,6 +1666,7 @@
     Contravariant: Contravariant,
     toString: toString,
     equals: equals,
+    lte: lte,
     concat: concat,
     empty: empty,
     map: map,
@@ -1594,6 +1713,7 @@
 //. [Plus]:                     https://github.com/fantasyland/fantasy-land#plus
 //. [Profunctor]:               https://github.com/fantasyland/fantasy-land#profunctor
 //. [Semigroup]:                https://github.com/fantasyland/fantasy-land#semigroup
+//. [Ord]:                      https://github.com/fantasyland/fantasy-land#ord
 //. [Setoid]:                   https://github.com/fantasyland/fantasy-land#setoid
 //. [Traversable]:              https://github.com/fantasyland/fantasy-land#traversable
 //. [`fantasy-land/alt`]:       https://github.com/fantasyland/fantasy-land#alt-method

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sanctuary-type-identifiers": "1.0.x"
   },
   "devDependencies": {
-    "doctest": "0.10.x",
+    "doctest": "0.12.x",
     "eslint": "3.19.x",
     "fantasy-land": "3.1.0",
     "istanbul": "0.4.x",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "doctest": "0.12.x",
     "eslint": "3.19.x",
-    "fantasy-land": "3.1.0",
+    "fantasy-land": "^3.2.0",
     "istanbul": "0.4.x",
     "mocha": "2.x.x",
     "remark-cli": "3.x.x",

--- a/test/Identity.js
+++ b/test/Identity.js
@@ -19,6 +19,10 @@ Identity.prototype[FL.equals] = function(other) {
   return Z.equals(other.value, this.value);
 };
 
+Identity.prototype[FL.lte] = function(other) {
+  return Z.lte(this.value, other.value);
+};
+
 Identity.prototype[FL.concat] = function(other) {
   return Identity(Z.concat(this.value, other.value));
 };

--- a/test/List.js
+++ b/test/List.js
@@ -45,6 +45,16 @@ List.prototype[FL.equals] = function(other) {
       Z.equals(other.tail, this.tail);
 };
 
+List.prototype[FL.lte] = function(other) {
+  if (this.tag === 'Nil') {
+    return true;
+  }
+
+  return Z.equals(other.head, this.head)
+    ? Z.lte(this.tail, other.tail)
+    : Z.lte(this.head, other.head);
+};
+
 List.prototype[FL.concat] = function(other) {
   return this.tag === 'Nil' ?
     other :

--- a/test/index.js
+++ b/test/index.js
@@ -186,12 +186,21 @@ test('Setoid', function() {
   eq(Z.Setoid.test({'@@type': 'my-package/Quux'}), true);
 });
 
+test('Ord', function() {
+  eq(type(Z.Ord), 'sanctuary-type-classes/TypeClass');
+  eq(Z.Ord.name, 'sanctuary-type-classes/Ord');
+  eq(Z.Ord.test(null), true);
+  eq(Z.Ord.test(''), true);
+  eq(Z.Ord.test([]), true);
+});
+
 test('Semigroup', function() {
   eq(type(Z.Semigroup), 'sanctuary-type-classes/TypeClass');
   eq(Z.Semigroup.name, 'sanctuary-type-classes/Semigroup');
   eq(Z.Semigroup.test(null), false);
   eq(Z.Semigroup.test(''), true);
   eq(Z.Semigroup.test([]), true);
+  eq(Z.Semigroup.test(Math.abs), true);
   eq(Z.Semigroup.test({}), true);
 });
 
@@ -210,6 +219,7 @@ test('Functor', function() {
   eq(Z.Functor.test(null), false);
   eq(Z.Functor.test(''), false);
   eq(Z.Functor.test([]), true);
+  eq(Z.Functor.test(Math.abs), true);
   eq(Z.Functor.test({}), true);
 });
 
@@ -239,6 +249,7 @@ test('Apply', function() {
   eq(Z.Apply.test(null), false);
   eq(Z.Apply.test(''), false);
   eq(Z.Apply.test([]), true);
+  eq(Z.Apply.test(Math.abs), true);
   eq(Z.Apply.test({}), true);
 });
 
@@ -248,6 +259,7 @@ test('Applicative', function() {
   eq(Z.Applicative.test(null), false);
   eq(Z.Applicative.test(''), false);
   eq(Z.Applicative.test([]), true);
+  eq(Z.Applicative.test(Math.abs), true);
   eq(Z.Applicative.test({}), false);
 });
 
@@ -257,6 +269,7 @@ test('Chain', function() {
   eq(Z.Chain.test(null), false);
   eq(Z.Chain.test(''), false);
   eq(Z.Chain.test([]), true);
+  eq(Z.Chain.test(Math.abs), true);
   eq(Z.Chain.test({}), false);
 });
 
@@ -275,6 +288,7 @@ test('Monad', function() {
   eq(Z.Monad.test(null), false);
   eq(Z.Monad.test(''), false);
   eq(Z.Monad.test([]), true);
+  eq(Z.Monad.test(Math.abs), true);
   eq(Z.Monad.test({}), false);
 });
 
@@ -284,6 +298,7 @@ test('Alt', function() {
   eq(Z.Alt.test(null), false);
   eq(Z.Alt.test(''), false);
   eq(Z.Alt.test([]), true);
+  eq(Z.Alt.test(function(_) { return []; }), true);
   eq(Z.Alt.test({}), true);
 });
 
@@ -432,8 +447,8 @@ test('equals', function() {
   eq(Z.equals(true, new Boolean(true)), false);
   eq(Z.equals(new Boolean(true), true), false);
   eq(Z.equals(0, 0), true);
-  eq(Z.equals(0, -0), false);
-  eq(Z.equals(-0, 0), false);
+  eq(Z.equals(0, -0), true);
+  eq(Z.equals(-0, 0), true);
   eq(Z.equals(-0, -0), true);
   eq(Z.equals(NaN, NaN), true);
   eq(Z.equals(Infinity, Infinity), true);
@@ -443,14 +458,10 @@ test('equals', function() {
   eq(Z.equals(NaN, Math.PI), false);
   eq(Z.equals(Math.PI, NaN), false);
   eq(Z.equals(new Number(0), new Number(0)), true);
-  eq(Z.equals(new Number(0), new Number(-0)), false);
-  eq(Z.equals(new Number(-0), new Number(0)), false);
+  eq(Z.equals(new Number(0), new Number(-0)), true);
+  eq(Z.equals(new Number(-0), new Number(0)), true);
   eq(Z.equals(new Number(-0), new Number(-0)), true);
   eq(Z.equals(new Number(NaN), new Number(NaN)), true);
-  eq(Z.equals(new Number(Infinity), new Number(Infinity)), true);
-  eq(Z.equals(new Number(Infinity), new Number(-Infinity)), false);
-  eq(Z.equals(new Number(-Infinity), new Number(Infinity)), false);
-  eq(Z.equals(new Number(-Infinity), new Number(-Infinity)), true);
   eq(Z.equals(new Number(NaN), new Number(Math.PI)), false);
   eq(Z.equals(new Number(Math.PI), new Number(NaN)), false);
   eq(Z.equals(42, new Number(42)), false);
@@ -483,7 +494,7 @@ test('equals', function() {
   eq(Z.equals([1, 2, 3], [1, 2]), false);
   eq(Z.equals([1, 2], [1, 2, 3]), false);
   eq(Z.equals([1, 2], [2, 1]), false);
-  eq(Z.equals([0], [-0]), false);
+  eq(Z.equals([0], [-0]), true);
   eq(Z.equals([NaN], [NaN]), true);
   eq(Z.equals(ones, ones), true);
   eq(Z.equals(ones, [1, [1, [1, [1, []]]]]), false);
@@ -496,7 +507,7 @@ test('equals', function() {
   eq(Z.equals(args(1, 2, 3), args(1, 2)), false);
   eq(Z.equals(args(1, 2), args(1, 2, 3)), false);
   eq(Z.equals(args(1, 2), args(2, 1)), false);
-  eq(Z.equals(args(0), args(-0)), false);
+  eq(Z.equals(args(0), args(-0)), true);
   eq(Z.equals(args(NaN), args(NaN)), true);
   eq(Z.equals(new Error('abc'), new Error('abc')), true);
   eq(Z.equals(new Error('abc'), new Error('xyz')), false);
@@ -509,7 +520,7 @@ test('equals', function() {
   eq(Z.equals({x: 1, y: 2, z: 3}, {x: 1, y: 2}), false);
   eq(Z.equals({x: 1, y: 2}, {x: 1, y: 2, z: 3}), false);
   eq(Z.equals({x: 1, y: 2}, {x: 2, y: 1}), false);
-  eq(Z.equals({x: 0}, {x: -0}), false);
+  eq(Z.equals({x: 0}, {x: -0}), true);
   eq(Z.equals({x: NaN}, {x: NaN}), true);
   eq(Z.equals(node1, node1), true);
   eq(Z.equals(node2, node2), true);
@@ -522,6 +533,78 @@ test('equals', function() {
   eq(Z.equals({'@@type': 'my-package/Quux'}, {'@@type': 'my-package/Quux'}), true);
   eq(Z.equals(Nothing.constructor, Maybe), true);
   eq(Z.equals(Just(0).constructor, Maybe), true);
+});
+
+test('lte', function() {
+  eq(Z.lte.length, 2);
+  eq(Z.lte.name, 'lte');
+
+  eq(Z.lte(null, null), true);
+  eq(Z.lte(null, undefined), false);
+  eq(Z.lte(undefined, null), false);
+  eq(Z.lte(undefined, undefined), true);
+  eq(Z.lte(false, false), true);
+  eq(Z.lte(false, true), true);
+  eq(Z.lte(true, false), false);
+  eq(Z.lte(true, true), true);
+  eq(Z.lte(new Boolean(false), new Boolean(false)), true);
+  eq(Z.lte(new Boolean(false), new Boolean(true)), true);
+  eq(Z.lte(new Boolean(true), new Boolean(false)), false);
+  eq(Z.lte(new Boolean(true), new Boolean(true)), true);
+  eq(Z.lte(false, new Boolean(false)), false);
+  eq(Z.lte(new Boolean(false), false), false);
+  eq(Z.lte(true, new Boolean(true)), false);
+  eq(Z.lte(new Boolean(true), true), false);
+  eq(Z.lte(0, 0), true);
+  eq(Z.lte(0, -0), true);
+  eq(Z.lte(-0, 0), true);
+  eq(Z.lte(-0, -0), true);
+  eq(Z.lte(NaN, NaN), true);
+  eq(Z.lte(NaN, Math.PI), false);
+  eq(Z.lte(Math.PI, NaN), false);
+  eq(Z.lte(new Number(0), new Number(0)), true);
+  eq(Z.lte(new Number(0), new Number(-0)), true);
+  eq(Z.lte(new Number(-0), new Number(0)), true);
+  eq(Z.lte(new Number(-0), new Number(-0)), true);
+  eq(Z.lte(new Number(NaN), new Number(NaN)), true);
+  eq(Z.lte(new Number(NaN), new Number(Math.PI)), false);
+  eq(Z.lte(new Number(Math.PI), new Number(NaN)), false);
+  eq(Z.lte(42, new Number(42)), false);
+  eq(Z.lte(new Number(42), 42), false);
+  eq(Z.lte(new Date(0), new Date(0)), true);
+  eq(Z.lte(new Date(0), new Date(1)), true);
+  eq(Z.lte(new Date(1), new Date(0)), false);
+  eq(Z.lte(new Date(1), new Date(1)), true);
+  eq(Z.lte(new Date(NaN), new Date(NaN)), true);
+  eq(Z.lte('', ''), true);
+  eq(Z.lte('abc', 'abc'), true);
+  eq(Z.lte('abc', 'xyz'), true);
+  eq(Z.lte('xyz', 'abc'), false);
+  eq(Z.lte(new String(''), new String('')), true);
+  eq(Z.lte(new String('abc'), new String('abc')), true);
+  eq(Z.lte(new String('abc'), new String('xyz')), true);
+  eq(Z.lte(new String('xyz'), new String('abc')), false);
+  eq(Z.lte('abc', new String('abc')), false);
+  eq(Z.lte(new String('abc'), 'abc'), false);
+  eq(Z.lte([], []), true);
+  eq(Z.lte([1, 2], [1, 2]), true);
+  eq(Z.lte([1, 2, 3], [1, 2]), false);
+  eq(Z.lte([1, 2], [1, 2, 3]), true);
+  eq(Z.lte([1, 2], [2, 1]), true);
+  eq(Z.lte([0], [-0]), true);
+  eq(Z.lte([NaN], [NaN]), true);
+  eq(Z.lte(ones, ones), true);
+  eq(Z.lte(args(), args()), true);
+  eq(Z.lte(args(1, 2), args(1, 2)), true);
+  eq(Z.lte(args(1, 2, 3), args(1, 2)), false);
+  eq(Z.lte(args(1, 2), args(1, 2, 3)), true);
+  eq(Z.lte(args(1, 2), args(2, 1)), true);
+  eq(Z.lte(args(0), args(-0)), true);
+  eq(Z.lte(args(NaN), args(NaN)), true);
+  eq(Z.lte(Identity(Identity(Identity(0))), Identity(Identity(Identity(0)))), true);
+  eq(Z.lte(Identity(Identity(Identity(0))), Identity(Identity(Identity(1)))), true);
+  eq(Z.lte(Identity(Identity(Identity(1))), Identity(Identity(Identity(0)))), false);
+  eq(Z.lte(Identity(Identity(Identity(1))), Identity(Identity(Identity(1)))), true);
 });
 
 test('concat', function() {
@@ -541,6 +624,9 @@ test('concat', function() {
   eq(Z.concat({x: 1, y: 2}, {}), {x: 1, y: 2});
   eq(Z.concat({x: 1, y: 2}, {y: 3, z: 4}), {x: 1, y: 3, z: 4});
   eq(Z.concat(Identity(''), Identity('')), Identity(''));
+  eq(Z.concat(function(x) { return [x + 1]; },
+              function(x) { return [x]; })(2),
+     (function(x) { return [x + 1, x]; }(2)));
   eq(Z.concat(Identity(''), Identity('abc')), Identity('abc'));
   eq(Z.concat(Identity('abc'), Identity('')), Identity('abc'));
   eq(Z.concat(Identity('abc'), Identity('def')), Identity('abcdef'));
@@ -756,6 +842,9 @@ test('alt', function() {
   eq(Z.alt(Nothing, Just(1)), Just(1));
   eq(Z.alt(Just(2), Nothing), Just(2));
   eq(Z.alt(Just(3), Just(4)), Just(3));
+  eq(Z.concat(function(x) { return [x + 1]; },
+              function(x) { return [x]; })(2),
+     (function(x) { return [x + 1, x]; }(2)));
 });
 
 test('zero', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -455,6 +455,8 @@ test('equals', function() {
   eq(Z.equals(new Number(Math.PI), new Number(NaN)), false);
   eq(Z.equals(42, new Number(42)), false);
   eq(Z.equals(new Number(42), 42), false);
+  eq(Z.equals(NaN, new Number(NaN)), false);
+  eq(Z.equals(new Number(NaN), NaN), false);
   eq(Z.equals(new Date(0), new Date(0)), true);
   eq(Z.equals(new Date(0), new Date(1)), false);
   eq(Z.equals(new Date(1), new Date(0)), false);


### PR DESCRIPTION
Several missing instances have been added. The majority are for `Ord`, though there is also an `Alt` and `Semigroup` instance for `Function`. Basically a port of https://github.com/fantasyland/fantasy-land/pull/244

I've hopefully done a satisfactory job of tests, format, etc!