### PR TITLE
perform typeof check in ‘equals’

### DIFF
--- a/index.js
+++ b/index.js
@@ -518,7 +518,9 @@
 
   //  Boolean$prototype$equals :: Boolean ~> Boolean -> Boolean
   function Boolean$prototype$equals(other) {
-    return typeof other === typeof this && other.valueOf() === this.valueOf();
+    return typeof this === 'object' ?
+      equals(this.valueOf(), other.valueOf()) :
+      this === other;
   }
 
   //  Number$prototype$toString :: Number ~> () -> String
@@ -530,11 +532,9 @@
 
   //  Number$prototype$equals :: Number ~> Number -> Boolean
   function Number$prototype$equals(other) {
-    return typeof other === 'object' ?
-      typeof this === 'object' &&
-        equals(this.valueOf(), other.valueOf()) :
-      isNaN(other) && isNaN(this) ||
-        other === this && 1 / other === 1 / this;
+    return typeof this === 'object' ?
+      equals(this.valueOf(), other.valueOf()) :
+      isNaN(this) && isNaN(other) || this === other && 1 / this === 1 / other;
   }
 
   //  Date$prototype$toString :: Date ~> () -> String
@@ -580,7 +580,9 @@
 
   //  String$prototype$equals :: String ~> String -> Boolean
   function String$prototype$equals(other) {
-    return typeof other === typeof this && other.valueOf() === this.valueOf();
+    return typeof this === 'object' ?
+      equals(this.valueOf(), other.valueOf()) :
+      this === other;
   }
 
   //  String$prototype$concat :: String ~> String -> String
@@ -1016,9 +1018,7 @@
     var $pairs = [];
 
     return function equals(x, y) {
-      if (type(x) !== type(y)) {
-        return false;
-      }
+      if (typeof x !== typeof y || type(x) !== type(y)) return false;
 
       //  This algorithm for comparing circular data structures was
       //  suggested in <http://stackoverflow.com/a/40622794/312785>.

--- a/test/index.js
+++ b/test/index.js
@@ -455,6 +455,8 @@ test('equals', function() {
   eq(Z.equals(new Number(Math.PI), new Number(NaN)), false);
   eq(Z.equals(42, new Number(42)), false);
   eq(Z.equals(new Number(42), 42), false);
+  eq(Z.equals(NaN, new Number(NaN)), false);
+  eq(Z.equals(new Number(NaN), NaN), false);
   eq(Z.equals(new Date(0), new Date(0)), true);
   eq(Z.equals(new Date(0), new Date(1)), false);
   eq(Z.equals(new Date(1), new Date(0)), false);


### PR DESCRIPTION
Commit message:

>     This simplifies Number$prototype$equals (and the corresponding Boolean
>     and String functions) by reducing the number of permutations from four
>     to two (indicated by *):
>
>         typeof this     typeof other
>         --------------------------------
>       * 'object'        'object'
>         'object'        'number'
>         'number'        'object'
>       * 'number'        'number'
>
>     This commit also fixes a bug which caused Z.equals(new Number(NaN), NaN)
>     to evaluate true rather than false.
