### PR TITLE
Update Extend instance for Array

### DIFF
--- a/index.js
+++ b/index.js
@@ -796,7 +796,7 @@
 
   //  Array$prototype$extend :: Array a ~> (Array a -> b) -> Array b
   function Array$prototype$extend(f) {
-    return [f(this)];
+    return this.map(function(_, idx, xs) { return f(xs.slice(idx)); });
   }
 
   //  Arguments$prototype$toString :: Arguments ~> String
@@ -1791,8 +1791,8 @@
   //. built-in types: Array.
   //.
   //. ```javascript
-  //. > extend(xs => xs.length, ['foo', 'bar', 'baz', 'quux'])
-  //. [4]
+  //. > extend(ss => ss.join(''), ['x', 'y', 'z'])
+  //. ['xyz', 'yz', 'z']
   //. ```
   function extend(f, extend_) {
     return Extend.methods.extend(extend_)(f);

--- a/test/index.js
+++ b/test/index.js
@@ -66,6 +66,15 @@ function inc(x) {
   return x + 1;
 }
 
+//  joinWith :: String -> Array String -> String
+function joinWith(s) {
+  eq(arguments.length, joinWith.length);
+  return function joinWith$1(ss) {
+    eq(arguments.length, joinWith$1.length);
+    return ss.join(s);
+  };
+}
+
 //  length :: List a -> Integer
 function length(xs) {
   eq(arguments.length, length.length);
@@ -1054,8 +1063,10 @@ test('extend', function() {
   eq(Z.extend.length, 2);
   eq(Z.extend.name, 'extend');
 
-  eq(Z.extend(length, []), [0]);
-  eq(Z.extend(length, [1, 2, 3]), [3]);
+  eq(Z.extend(joinWith(''), []), []);
+  eq(Z.extend(joinWith(''), ['x']), ['x']);
+  eq(Z.extend(joinWith(''), ['x', 'y']), ['xy', 'y']);
+  eq(Z.extend(joinWith(''), ['x', 'y', 'z']), ['xyz', 'yz', 'z']);
   eq(Z.extend(function(id) { return Z.reduce(add, 1, id); }, Identity(42)), Identity(43));
 });
 


### PR DESCRIPTION
Previously, the extend instance was simply `f => [f(this)]`, which is essentially `pure . f`. The common "comonadic" version is introduced in this PR, along with updated tests.