### PR TITLE
Add benchmarking

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,14 @@
 {
   "root": true,
-  "extends": ["./node_modules/sanctuary-style/eslint-es3.json"]
+  "extends": ["./node_modules/sanctuary-style/eslint-es3.json"],
+  "overrides": [
+    {
+      "files": ["bench/**/*.js"],
+      "env": {"node": true},
+      "rules": {
+        "key-spacing": ["off"],
+        "max-len": ["off"]
+      }
+    }
+  ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/bench/node_modules/
 /coverage/
 /node_modules/

--- a/bench/.npmrc
+++ b/bench/.npmrc
@@ -1,0 +1,2 @@
+package-lock=false
+save=false

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,14 @@
+# Benchmarks
+
+## Running
+
+* Install node modules required for the benchmark you wish to run
+* Use `npm run bench -- --help` for options
+
+For example, let's say you like to know how the performance of `toString`
+compares to what it was at version 2.x.x:
+
+```console
+$ (cd bench && npm install sanctuary-type-classes@2.x.x)
+$ npm run bench -- --benchmark old-vs-new --match methods.toString.*
+```

--- a/bench/old-vs-new.js
+++ b/bench/old-vs-new.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var benchmark = require('sanctuary-benchmark');
+
+var oldZ = require('sanctuary-type-classes');
+var newZ = require('..');
+
+
+var Identity = require('../test/Identity');
+
+//  inc :: Number -> Number
+function inc(x) {
+  return x + 1;
+}
+
+//  prep :: StrMap Function -> StrMap (Pair (StrMap a) Function)
+function prep(specs) {
+  return newZ.map(function(f) { return [{}, f]; }, specs);
+}
+
+module.exports = benchmark(oldZ, newZ, {leftHeader: 'old', rightHeader: 'new'}, prep({
+  'functions.of.Array':          function(Z) { Z.of(Array, 42); },
+  'functions.of.Identity':       function(Z) { Z.of(Identity, 42); },
+  'methods.equals.Identity':     function(Z) { Z.equals(Identity(0), Identity(0)); },
+  'methods.equals.Object':       function(Z) { Z.equals({x: 0, y: 0}, {y: 0, x: 0}); },
+  'methods.map.Array':           function(Z) { Z.map(inc, [1, 2, 3]); },
+  'methods.map.Identity':        function(Z) { Z.map(inc, Identity(1)); },
+  'methods.toString.Identity':   function(Z) { Z.toString(Identity(0)); },
+  'methods.toString.Object':     function(Z) { Z.toString({x: 0, y: 0}); },
+  'methods.toString.String':     function(Z) { Z.toString('hello'); },
+  'test.Comonad.Identity':       function(Z) { Z.Comonad.test(Identity(0)); },
+  'test.Contravariant.Function': function(Z) { Z.Contravariant.test(Math.abs); }
+}));

--- a/bench/package.json
+++ b/bench/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "sanctuary-type-classes-benchmarks",
+  "version": "0.0.0",
+  "description": "A package.json for the purpose of being able to install dependencies in here",
+  "license": "MIT",
+  "private": true
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/sanctuary-js/sanctuary-type-classes.git"
   },
   "scripts": {
+    "bench": "sanctuary-benchmark",
     "doctest": "sanctuary-doctest",
     "lint": "sanctuary-lint",
     "release": "sanctuary-release",
@@ -18,6 +19,7 @@
   },
   "devDependencies": {
     "fantasy-land": "3.5.0",
+    "sanctuary-benchmark": "1.0.x",
     "sanctuary-scripts": "1.0.x"
   },
   "files": [

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euf -o pipefail
+
+node_modules/.bin/sanctuary-lint
+
+node_modules/.bin/eslint \
+  --report-unused-disable-directives \
+  -- bench/*.js


### PR DESCRIPTION
Adds benchmarks inpired by @safareli's [work on Daggy](https://github.com/fantasyland/daggy/tree/master/bench)

I created a sub-package in order to be able to do separate dependency management. This is handy to shave some time off the installation of the parent package (as most won't be running the benchmarks), but most importantly, to allow NPM to install `sanctuary-type-classes` as a dependency of itself.

---

I have a few questions about licensing.

1. @safareli published his work [under the MIT licence](https://github.com/fantasyland/daggy/blob/master/package.json#L12). Since I'm including "a significant portion" of his code in this PR, shouldn't I be including the Daggy legal notice? And if so, the actual license text does not appear to be present in Daggy.
2. Which license should I use in this sub-package? I've currently set it to MIT, so not to publish anything with reduced restrictions over the license of the parent package. But I would like to take this code and use it in other projects, without having to include any legal notices. I therefore would prefer to change the license to WTFPL and include a `LICENCE` file. I'm not sure if that's the right approach, though.
