### PR TITLE
derive ‘append’ and ‘prepend’ from ‘concat’ and ‘of’

### DIFF
--- a/index.js
+++ b/index.js
@@ -1568,6 +1568,44 @@
     return Applicative.methods.of(typeRep)(x);
   }
 
+  //# append :: (Applicative f, Semigroup (f a)) => (a, f a) -> f a
+  //.
+  //. Returns the result of appending the first argument to the second.
+  //.
+  //. This function is derived from [`concat`](#concat) and [`of`](#of).
+  //.
+  //. See also [`prepend`](#prepend).
+  //.
+  //. ```javascript
+  //. > append(3, [1, 2])
+  //. [1, 2, 3]
+  //.
+  //. > append(3, Cons(1, Cons(2, Nil)))
+  //. Cons(1, Cons(2, Cons(3, Nil)))
+  //. ```
+  function append(x, xs) {
+    return concat(xs, of(xs.constructor, x));
+  }
+
+  //# prepend :: (Applicative f, Semigroup (f a)) => (a, f a) -> f a
+  //.
+  //. Returns the result of prepending the first argument to the second.
+  //.
+  //. This function is derived from [`concat`](#concat) and [`of`](#of).
+  //.
+  //. See also [`append`](#append).
+  //.
+  //. ```javascript
+  //. > prepend(1, [2, 3])
+  //. [1, 2, 3]
+  //.
+  //. > prepend(1, Cons(2, Cons(3, Nil)))
+  //. Cons(1, Cons(2, Cons(3, Nil)))
+  //. ```
+  function prepend(x, xs) {
+    return concat(of(xs.constructor, x), xs);
+  }
+
   //# chain :: Chain m => (a -> m b, m a) -> m b
   //.
   //. Function wrapper for [`fantasy-land/chain`][].
@@ -1893,6 +1931,8 @@
     apFirst: apFirst,
     apSecond: apSecond,
     of: of,
+    append: append,
+    prepend: prepend,
     chain: chain,
     join: join,
     chainRec: chainRec,

--- a/test/Maybe.js
+++ b/test/Maybe.js
@@ -13,6 +13,14 @@ function _Maybe(tag, value) {
   this.isNothing = tag === 'Nothing';
   this.isJust = tag === 'Just';
   if (this.isJust) this.value = value;
+
+  if (this.isNothing || Z.Setoid.test(this.value)) {
+    this[FL.equals] = Maybe$prototype$equals;
+  }
+
+  if (this.isNothing || Z.Semigroup.test(this.value)) {
+    this[FL.concat] = Maybe$prototype$concat;
+  }
 }
 
 Maybe['@@type'] = 'sanctuary-type-classes/Maybe';
@@ -27,10 +35,16 @@ Maybe[FL.of] = Maybe.Just;
 
 Maybe[FL.zero] = Maybe[FL.empty];
 
-Maybe.prototype[FL.equals] = function(other) {
+function Maybe$prototype$equals(other) {
   return this.isNothing ? other.isNothing
-                        : other.isJust && Z.equals(other.value, this.value);
-};
+                        : other.isJust && Z.equals(this.value, other.value);
+}
+
+function Maybe$prototype$concat(other) {
+  return this.isNothing ? other :
+         other.isNothing ? this :
+         /* otherwise */ Maybe.Just(Z.concat(this.value, other.value));
+}
 
 Maybe.prototype[FL.map] = function(f) {
   return this.isJust ? Maybe.Just(f(this.value)) : Maybe.Nothing;

--- a/test/index.js
+++ b/test/index.js
@@ -908,6 +908,32 @@ test('of', function() {
   eq(Z.of(Maybe, 42), Just(42));
 });
 
+test('append', function() {
+  eq(Z.append.length, 2);
+  eq(Z.append.name, 'append');
+
+  eq(Z.append(3, []), [3]);
+  eq(Z.append(3, [1, 2]), [1, 2, 3]);
+  eq(Z.append(3, Nil), Cons(3, Nil));
+  eq(Z.append(3, Cons(1, Cons(2, Nil))), Cons(1, Cons(2, Cons(3, Nil))));
+  eq(Z.append([5, 6], [[1, 2], [3, 4]]), [[1, 2], [3, 4], [5, 6]]);
+  eq(Z.append([2], Nothing), Just([2]));
+  eq(Z.append([2], Just([1])), Just([1, 2]));
+});
+
+test('prepend', function() {
+  eq(Z.prepend.length, 2);
+  eq(Z.prepend.name, 'prepend');
+
+  eq(Z.prepend(1, []), [1]);
+  eq(Z.prepend(1, [2, 3]), [1, 2, 3]);
+  eq(Z.prepend(1, Nil), Cons(1, Nil));
+  eq(Z.prepend(1, Cons(2, Cons(3, Nil))), Cons(1, Cons(2, Cons(3, Nil))));
+  eq(Z.prepend([1, 2], [[3, 4], [5, 6]]), [[1, 2], [3, 4], [5, 6]]);
+  eq(Z.prepend([1], Nothing), Just([1]));
+  eq(Z.prepend([1], Just([2])), Just([1, 2]));
+});
+
 test('chain', function() {
   eq(Z.chain.length, 2);
   eq(Z.chain.name, 'chain');


### PR DESCRIPTION
`append` and `prepend` are defined in Sanctuary, but based on <https://github.com/sanctuary-js/sanctuary/pull/414#issuecomment-308724784> we'd like to move the definitions here. :)
