### PR TITLE
derive ‘min’ and ‘max’ from ‘lte’

### DIFF
--- a/index.js
+++ b/index.js
@@ -1305,6 +1305,50 @@
     return lte(y, x);
   }
 
+  //# min :: Ord a => (a, a) -> a
+  //.
+  //. Returns the smaller of its two arguments.
+  //.
+  //. This function is derived from [`lte`](#lte).
+  //.
+  //. See also [`max`](#max).
+  //.
+  //. ```javascript
+  //. > min(10, 2)
+  //. 2
+  //.
+  //. > min(new Date('1999-12-31'), new Date('2000-01-01'))
+  //. new Date('1999-12-31')
+  //.
+  //. > min('10', '2')
+  //. '10'
+  //. ```
+  function min(x, y) {
+    return lte(x, y) ? x : y;
+  }
+
+  //# max :: Ord a => (a, a) -> a
+  //.
+  //. Returns the larger of its two arguments.
+  //.
+  //. This function is derived from [`lte`](#lte).
+  //.
+  //. See also [`min`](#min).
+  //.
+  //. ```javascript
+  //. > max(10, 2)
+  //. 10
+  //.
+  //. > max(new Date('1999-12-31'), new Date('2000-01-01'))
+  //. new Date('2000-01-01')
+  //.
+  //. > max('10', '2')
+  //. '2'
+  //. ```
+  function max(x, y) {
+    return lte(x, y) ? y : x;
+  }
+
   //# compose :: Semigroupoid c => (c j k, c i j) -> c i k
   //.
   //. Function wrapper for [`fantasy-land/compose`][].
@@ -1918,6 +1962,8 @@
     lte: lte,
     gt: gt,
     gte: gte,
+    min: min,
+    max: max,
     compose: compose,
     id: id,
     concat: concat,

--- a/test/index.js
+++ b/test/index.js
@@ -755,6 +755,22 @@ test('gte', function() {
   eq(Z.gte('abc', 123), false);
 });
 
+test('min', function() {
+  eq(Z.min.length, 2);
+  eq(Z.min.name, 'min');
+
+  eq(Z.min(0, 1), 0);
+  eq(Z.min(['x', 'x'], ['x']), ['x']);
+});
+
+test('max', function() {
+  eq(Z.max.length, 2);
+  eq(Z.max.name, 'max');
+
+  eq(Z.max(0, 1), 1);
+  eq(Z.max(['x', 'x'], ['x']), ['x', 'x']);
+});
+
 test('compose', function() {
   eq(Z.compose.length, 2);
   eq(Z.compose.name, 'compose');


### PR DESCRIPTION
This pull request is part of the effort to define "derived" `S` functions as `Z` functions.
