### PR TITLE
derive ‘elem’ from ‘equals’ and ‘reduce’

### DIFF
--- a/index.js
+++ b/index.js
@@ -1853,6 +1853,42 @@
     return reduce(function(n, _) { return n + 1; }, 0, foldable);
   }
 
+  //# elem :: (Setoid a, Foldable f) => (a, f a) -> Boolean
+  //.
+  //. Takes a value and a structure and returns `true` if the
+  //. value is an element of the structure; `false` otherwise.
+  //.
+  //. This function is derived from [`equals`](#equals) and
+  //. [`reduce`](#reduce).
+  //.
+  //. ```javascript
+  //. > elem('c', ['a', 'b', 'c'])
+  //. true
+  //.
+  //. > elem('x', ['a', 'b', 'c'])
+  //. false
+  //.
+  //. > elem(3, {x: 1, y: 2, z: 3})
+  //. true
+  //.
+  //. > elem(8, {x: 1, y: 2, z: 3})
+  //. false
+  //.
+  //. > elem(0, Just(0))
+  //. true
+  //.
+  //. > elem(0, Just(1))
+  //. false
+  //.
+  //. > elem(0, Nothing)
+  //. false
+  //. ```
+  function elem(x, foldable) {
+    return reduce(function(b, y) { return b || equals(x, y); },
+                  false,
+                  foldable);
+  }
+
   //# traverse :: (Applicative f, Traversable t) => (TypeRep f, a -> f b, t a) -> f (t b)
   //.
   //. Function wrapper for [`fantasy-land/traverse`][].
@@ -1988,6 +2024,7 @@
     zero: zero,
     reduce: reduce,
     size: size,
+    elem: elem,
     traverse: traverse,
     sequence: sequence,
     extend: extend,

--- a/test/index.js
+++ b/test/index.js
@@ -1086,6 +1086,23 @@ test('size', function() {
   eq(Z.size(Tuple('abc', 123)), 1);
 });
 
+test('elem', function() {
+  eq(Z.elem.length, 2);
+  eq(Z.elem.name, 'elem');
+
+  eq(Z.elem('a', ['a', 'b', 'c']), true);
+  eq(Z.elem('b', ['a', 'b', 'c']), true);
+  eq(Z.elem('c', ['a', 'b', 'c']), true);
+  eq(Z.elem('d', ['a', 'b', 'c']), false);
+  eq(Z.elem(1, {x: 1, y: 2, z: 3}), true);
+  eq(Z.elem(2, {x: 1, y: 2, z: 3}), true);
+  eq(Z.elem(3, {x: 1, y: 2, z: 3}), true);
+  eq(Z.elem(4, {x: 1, y: 2, z: 3}), false);
+  eq(Z.elem(0, Just(0)), true);
+  eq(Z.elem(0, Just(1)), false);
+  eq(Z.elem(0, Nothing), false);
+});
+
 test('traverse', function() {
   eq(Z.traverse.length, 3);
   eq(Z.traverse.name, 'traverse');


### PR DESCRIPTION
This pull request is part of the effort to define "derived" `S` functions as `Z` functions.
