### PR TITLE
derive ‘reverse’ from ‘concat’, ‘empty’, ‘of’, and ‘reduce’

### DIFF
--- a/index.js
+++ b/index.js
@@ -1889,6 +1889,29 @@
                   foldable);
   }
 
+  //# reverse :: (Applicative f, Foldable f, Monoid (f a)) => f a -> f a
+  //.
+  //. Reverses the elements of the given structure.
+  //.
+  //. This function is derived from [`concat`](#concat), [`empty`](#empty),
+  //. [`of`](#of), and [`reduce`](#reduce).
+  //.
+  //. ```javascript
+  //. > reverse([1, 2, 3])
+  //. [3, 2, 1]
+  //.
+  //. > reverse(Cons(1, Cons(2, Cons(3, Nil))))
+  //. Cons(3, Cons(2, Cons(1, Nil)))
+  //. ```
+  function reverse(foldable) {
+    //  Fast path for arrays.
+    if (Array.isArray(foldable)) return foldable.slice().reverse();
+    var F = foldable.constructor;
+    return reduce(function(xs, x) { return concat(of(F, x), xs); },
+                  empty(F),
+                  foldable);
+  }
+
   //# traverse :: (Applicative f, Traversable t) => (TypeRep f, a -> f b, t a) -> f (t b)
   //.
   //. Function wrapper for [`fantasy-land/traverse`][].
@@ -2025,6 +2048,7 @@
     reduce: reduce,
     size: size,
     elem: elem,
+    reverse: reverse,
     traverse: traverse,
     sequence: sequence,
     extend: extend,

--- a/test/index.js
+++ b/test/index.js
@@ -1103,6 +1103,20 @@ test('elem', function() {
   eq(Z.elem(0, Nothing), false);
 });
 
+test('reverse', function() {
+  eq(Z.reverse.length, 1);
+  eq(Z.reverse.name, 'reverse');
+
+  eq(Z.reverse([]), []);
+  eq(Z.reverse([1]), [1]);
+  eq(Z.reverse([1, 2]), [2, 1]);
+  eq(Z.reverse([1, 2, 3]), [3, 2, 1]);
+  eq(Z.reverse(Nil), Nil);
+  eq(Z.reverse(Cons(1, Nil)), Cons(1, Nil));
+  eq(Z.reverse(Cons(1, Cons(2, Nil))), Cons(2, Cons(1, Nil)));
+  eq(Z.reverse(Cons(1, Cons(2, Cons(3, Nil)))), Cons(3, Cons(2, Cons(1, Nil))));
+});
+
 test('traverse', function() {
   eq(Z.traverse.length, 3);
   eq(Z.traverse.name, 'traverse');


### PR DESCRIPTION
This pull request is part of the effort to define "derived" `S` functions as `Z` functions.
