### PR TITLE
derive ‘sort’ and ‘sortBy’ from ‘lte’, ‘concat’, ‘empty’, ‘of’, ‘reduce’

### DIFF
--- a/index.js
+++ b/index.js
@@ -1912,6 +1912,75 @@
                   foldable);
   }
 
+  //# sort :: (Ord a, Applicative f, Foldable f, Monoid (f a)) => f a -> f a
+  //.
+  //. Performs a [stable sort][] of the elements of the given structure,
+  //. using [`lte`](#lte) for comparisons.
+  //.
+  //. This function is derived from [`lte`](#lte), [`concat`](#concat),
+  //. [`empty`](#empty), [`of`](#of), and [`reduce`](#reduce).
+  //.
+  //. See also [`sortBy`](#sortBy).
+  //.
+  //. ```javascript
+  //. > sort(['foo', 'bar', 'baz'])
+  //. ['bar', 'baz', 'foo']
+  //.
+  //. > sort([Just(2), Nothing, Just(1)])
+  //. [Nothing, Just(1), Just(2)]
+  //.
+  //. > sort(Cons('foo', Cons('bar', Cons('baz', Nil))))
+  //. Cons('bar', Cons('baz', Cons('foo', Nil)))
+  //. ```
+  function sort(foldable) {
+    return sortBy(identity, foldable);
+  }
+
+  //# sortBy :: (Ord b, Applicative f, Foldable f, Monoid (f a)) => (a -> b, f a) -> f a
+  //.
+  //. Performs a [stable sort][] of the elements of the given structure,
+  //. using [`lte`](#lte) to compare the values produced by applying the
+  //. given function to each element of the structure.
+  //.
+  //. This function is derived from [`lte`](#lte), [`concat`](#concat),
+  //. [`empty`](#empty), [`of`](#of), and [`reduce`](#reduce).
+  //.
+  //. See also [`sort`](#sort).
+  //.
+  //. ```javascript
+  //. > sortBy(s => s.length, ['red', 'green', 'blue'])
+  //. ['red', 'blue', 'green']
+  //.
+  //. > sortBy(s => s.length, ['black', 'white'])
+  //. ['black', 'white']
+  //.
+  //. > sortBy(s => s.length, ['white', 'black'])
+  //. ['white', 'black']
+  //.
+  //. > sortBy(s => s.length, Cons('red', Cons('green', Cons('blue', Nil))))
+  //. Cons('red', Cons('blue', Cons('green', Nil)))
+  //. ```
+  function sortBy(f, foldable) {
+    var rs = reduce(function(xs, x) {
+      var fx = f(x);
+      var lower = 0;
+      var upper = xs.length;
+      while (lower < upper) {
+        var idx = Math.floor((lower + upper) / 2);
+        if (lte(xs[idx].fx, fx)) lower = idx + 1; else upper = idx;
+      }
+      xs.splice(lower, 0, {x: x, fx: fx});
+      return xs;
+    }, [], foldable);
+
+    var F = foldable.constructor;
+    var result = empty(F);
+    for (var idx = 0; idx < rs.length; idx += 1) {
+      result = concat(result, of(F, rs[idx].x));
+    }
+    return result;
+  }
+
   //# traverse :: (Applicative f, Traversable t) => (TypeRep f, a -> f b, t a) -> f (t b)
   //.
   //. Function wrapper for [`fantasy-land/traverse`][].
@@ -2049,6 +2118,8 @@
     size: size,
     elem: elem,
     reverse: reverse,
+    sort: sort,
+    sortBy: sortBy,
     traverse: traverse,
     sequence: sequence,
     extend: extend,
@@ -2101,4 +2172,5 @@
 //. [`fantasy-land/reduce`]:    https://github.com/fantasyland/fantasy-land#reduce-method
 //. [`fantasy-land/traverse`]:  https://github.com/fantasyland/fantasy-land#traverse-method
 //. [`fantasy-land/zero`]:      https://github.com/fantasyland/fantasy-land#zero-method
+//. [stable sort]:              https://en.wikipedia.org/wiki/Sorting_algorithm#Stability
 //. [type-classes]:             https://github.com/sanctuary-js/sanctuary-def#type-classes

--- a/test/Maybe.js
+++ b/test/Maybe.js
@@ -18,6 +18,10 @@ function _Maybe(tag, value) {
     this[FL.equals] = Maybe$prototype$equals;
   }
 
+  if (this.isNothing || Z.Ord.test(this.value)) {
+    this[FL.lte] = Maybe$prototype$lte;
+  }
+
   if (this.isNothing || Z.Semigroup.test(this.value)) {
     this[FL.concat] = Maybe$prototype$concat;
   }
@@ -38,6 +42,10 @@ Maybe[FL.zero] = Maybe[FL.empty];
 function Maybe$prototype$equals(other) {
   return this.isNothing ? other.isNothing
                         : other.isJust && Z.equals(this.value, other.value);
+}
+
+function Maybe$prototype$lte(other) {
+  return this.isNothing || other.isJust && Z.lte(this.value, other.value);
 }
 
 function Maybe$prototype$concat(other) {

--- a/test/index.js
+++ b/test/index.js
@@ -1117,6 +1117,36 @@ test('reverse', function() {
   eq(Z.reverse(Cons(1, Cons(2, Cons(3, Nil)))), Cons(3, Cons(2, Cons(1, Nil))));
 });
 
+test('sort', function() {
+  eq(Z.sort.length, 1);
+  eq(Z.sort.name, 'sort');
+
+  eq(Z.sort([]), []);
+  eq(Z.sort(['foo']), ['foo']);
+  eq(Z.sort(['foo', 'bar']), ['bar', 'foo']);
+  eq(Z.sort(['foo', 'bar', 'baz']), ['bar', 'baz', 'foo']);
+  eq(Z.sort(Nil), Nil);
+  eq(Z.sort(Cons('foo', Nil)), Cons('foo', Nil));
+  eq(Z.sort(Cons('foo', Cons('bar', Nil))), Cons('bar', Cons('foo', Nil)));
+  eq(Z.sort(Cons('foo', Cons('bar', Cons('baz', Nil)))), Cons('bar', Cons('baz', Cons('foo', Nil))));
+});
+
+test('sortBy', function() {
+  eq(Z.sortBy.length, 2);
+  eq(Z.sortBy.name, 'sortBy');
+
+  function rank(card) { return card.rank; }
+  function suit(card) { return card.suit; }
+  var _7s = {rank: 7, suit: 's'};
+  var _5h = {rank: 5, suit: 'h'};
+  var _2h = {rank: 2, suit: 'h'};
+  var _5s = {rank: 5, suit: 's'};
+  eq(Z.sortBy(rank, [_7s, _5h, _2h, _5s]), [_2h, _5h, _5s, _7s]);
+  eq(Z.sortBy(rank, [_7s, _5s, _2h, _5h]), [_2h, _5s, _5h, _7s]);
+  eq(Z.sortBy(suit, [_7s, _5h, _2h, _5s]), [_5h, _2h, _7s, _5s]);
+  eq(Z.sortBy(suit, [_5s, _2h, _5h, _7s]), [_2h, _5h, _5s, _7s]);
+});
+
 test('traverse', function() {
   eq(Z.traverse.length, 3);
   eq(Z.traverse.name, 'traverse');


### PR DESCRIPTION
This pull request is part of the effort to define "derived" `S` functions as `Z` functions.
