### PR TITLE
derive ‘takeWhile’ and ‘dropWhile’ from ‘filter’

### DIFF
--- a/index.js
+++ b/index.js
@@ -1728,6 +1728,8 @@
   //. Cons(1, Cons(3, Nil))
   //. ```
   function filter(pred, m) {
+    //  Fast path for arrays.
+    if (Array.isArray(m)) return m.filter(function(x) { return pred(x); });
     var M = m.constructor;
     return reduce(function(m, x) { return pred(x) ? concat(m, of(M, x)) : m; },
                   empty(M),
@@ -1981,6 +1983,56 @@
     return result;
   }
 
+  //# takeWhile :: (Applicative f, Foldable f, Monoid (f a)) => (a -> Boolean, f a) -> f a
+  //.
+  //. Discards the first inner value which does not satisfy the predicate, and
+  //. all subsequent inner values.
+  //.
+  //. This function is derived from [`concat`](#concat), [`empty`](#empty),
+  //. [`of`](#of), and [`reduce`](#reduce).
+  //.
+  //. See also [`dropWhile`](#dropWhile).
+  //.
+  //. ```javascript
+  //. > takeWhile(s => /x/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. ['xy', 'xz', 'yx']
+  //.
+  //. > takeWhile(s => /y/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. ['xy']
+  //.
+  //. > takeWhile(s => /z/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. []
+  //. ```
+  function takeWhile(pred, foldable) {
+    var take = true;
+    return filter(function(x) { return take = take && pred(x); }, foldable);
+  }
+
+  //# dropWhile :: (Applicative f, Foldable f, Monoid (f a)) => (a -> Boolean, f a) -> f a
+  //.
+  //. Retains the first inner value which does not satisfy the predicate, and
+  //. all subsequent inner values.
+  //.
+  //. This function is derived from [`concat`](#concat), [`empty`](#empty),
+  //. [`of`](#of), and [`reduce`](#reduce).
+  //.
+  //. See also [`takeWhile`](#takeWhile).
+  //.
+  //. ```javascript
+  //. > dropWhile(s => /x/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. ['yz', 'zx', 'zy']
+  //.
+  //. > dropWhile(s => /y/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. ['xz', 'yx', 'yz', 'zx', 'zy']
+  //.
+  //. > dropWhile(s => /z/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. ['xy', 'xz', 'yx', 'yz', 'zx', 'zy']
+  //. ```
+  function dropWhile(pred, foldable) {
+    var take = false;
+    return filter(function(x) { return take = take || !pred(x); }, foldable);
+  }
+
   //# traverse :: (Applicative f, Traversable t) => (TypeRep f, a -> f b, t a) -> f (t b)
   //.
   //. Function wrapper for [`fantasy-land/traverse`][].
@@ -2120,6 +2172,8 @@
     reverse: reverse,
     sort: sort,
     sortBy: sortBy,
+    takeWhile: takeWhile,
+    dropWhile: dropWhile,
     traverse: traverse,
     sequence: sequence,
     extend: extend,

--- a/test/index.js
+++ b/test/index.js
@@ -1147,6 +1147,42 @@ test('sortBy', function() {
   eq(Z.sortBy(suit, [_5s, _2h, _5h, _7s]), [_2h, _5h, _5s, _7s]);
 });
 
+test('takeWhile', function() {
+  eq(Z.takeWhile.length, 2);
+  eq(Z.takeWhile.name, 'takeWhile');
+
+  eq(Z.takeWhile(odd, []), []);
+  eq(Z.takeWhile(odd, [1]), [1]);
+  eq(Z.takeWhile(odd, [1, 3]), [1, 3]);
+  eq(Z.takeWhile(odd, [1, 3, 6]), [1, 3]);
+  eq(Z.takeWhile(odd, [1, 3, 6, 10]), [1, 3]);
+  eq(Z.takeWhile(odd, [1, 3, 6, 10, 15]), [1, 3]);
+  eq(Z.takeWhile(odd, Nil), Nil);
+  eq(Z.takeWhile(odd, Cons(1, Nil)), Cons(1, Nil));
+  eq(Z.takeWhile(odd, Cons(1, Cons(3, Nil))), Cons(1, Cons(3, Nil)));
+  eq(Z.takeWhile(odd, Cons(1, Cons(3, Cons(6, Nil)))), Cons(1, Cons(3, Nil)));
+  eq(Z.takeWhile(odd, Cons(1, Cons(3, Cons(6, Cons(10, Nil))))), Cons(1, Cons(3, Nil)));
+  eq(Z.takeWhile(odd, Cons(1, Cons(3, Cons(6, Cons(10, Cons(15, Nil)))))), Cons(1, Cons(3, Nil)));
+});
+
+test('dropWhile', function() {
+  eq(Z.dropWhile.length, 2);
+  eq(Z.dropWhile.name, 'dropWhile');
+
+  eq(Z.dropWhile(odd, []), []);
+  eq(Z.dropWhile(odd, [1]), []);
+  eq(Z.dropWhile(odd, [1, 3]), []);
+  eq(Z.dropWhile(odd, [1, 3, 6]), [6]);
+  eq(Z.dropWhile(odd, [1, 3, 6, 10]), [6, 10]);
+  eq(Z.dropWhile(odd, [1, 3, 6, 10, 15]), [6, 10, 15]);
+  eq(Z.dropWhile(odd, Nil), Nil);
+  eq(Z.dropWhile(odd, Cons(1, Nil)), Nil);
+  eq(Z.dropWhile(odd, Cons(1, Cons(3, Nil))), Nil);
+  eq(Z.dropWhile(odd, Cons(1, Cons(3, Cons(6, Nil)))), Cons(6, Nil));
+  eq(Z.dropWhile(odd, Cons(1, Cons(3, Cons(6, Cons(10, Nil))))), Cons(6, Cons(10, Nil)));
+  eq(Z.dropWhile(odd, Cons(1, Cons(3, Cons(6, Cons(10, Cons(15, Nil)))))), Cons(6, Cons(10, Cons(15, Nil))));
+});
+
 test('traverse', function() {
   eq(Z.traverse.length, 3);
   eq(Z.traverse.name, 'traverse');


### PR DESCRIPTION
This pull request is part of the effort to define "derived" `S` functions as `Z` functions.

Commit message:

> This commit also improves the performance of `filter` for arrays.
