### PR TITLE
fantasy-land@3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "doctest": "0.12.x",
     "eslint": "4.9.x",
-    "fantasy-land": "3.4.0",
+    "fantasy-land": "3.5.0",
     "istanbul": "0.4.x",
     "mocha": "2.x.x",
     "remark-cli": "3.x.x",

--- a/test/List.js
+++ b/test/List.js
@@ -51,6 +51,14 @@ List.prototype[FL.concat] = function(other) {
     Cons(this.head, Z.concat(this.tail, other));
 };
 
+List.prototype[FL.filter] = function(pred) {
+  return this.tag === 'Nil' ?
+    Nil :
+    pred(this.head) ?
+      Cons(this.head, Z.filter(pred, this.tail)) :
+      Z.filter(pred, this.tail);
+};
+
 List.prototype[FL.map] = function(f) {
   return this.tag === 'Nil' ?
     Nil :

--- a/test/Maybe.js
+++ b/test/Maybe.js
@@ -54,6 +54,10 @@ function Maybe$prototype$concat(other) {
          /* otherwise */ Maybe.Just(Z.concat(this.value, other.value));
 }
 
+Maybe.prototype[FL.filter] = function(pred) {
+  return this.isJust && pred(this.value) ? this : Maybe.Nothing;
+};
+
 Maybe.prototype[FL.map] = function(f) {
   return this.isJust ? Maybe.Just(f(this.value)) : Maybe.Nothing;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -294,6 +294,16 @@ test('Group', function() {
   eq(Z.Group.test(Sum(0)), true);
 });
 
+test('Filterable', function() {
+  eq(type(Z.Filterable), 'sanctuary-type-classes/TypeClass');
+  eq(Z.Filterable.name, 'sanctuary-type-classes/Filterable');
+  eq(Z.Filterable.url, 'https://github.com/sanctuary-js/sanctuary-type-classes/tree/v' + version + '#Filterable');
+  eq(Z.Filterable.test(null), false);
+  eq(Z.Filterable.test(''), false);
+  eq(Z.Filterable.test([]), true);
+  eq(Z.Filterable.test({}), true);
+});
+
 test('Functor', function() {
   eq(type(Z.Functor), 'sanctuary-type-classes/TypeClass');
   eq(Z.Functor.name, 'sanctuary-type-classes/Functor');
@@ -853,6 +863,36 @@ test('invert', function() {
   eq(Z.invert(Sum(-5)), Sum(5));
 });
 
+test('filter', function() {
+  eq(Z.filter.length, 2);
+  eq(Z.filter.name, 'filter');
+
+  eq(Z.filter(odd, []), []);
+  eq(Z.filter(odd, [1, 2, 3, 4, 5]), [1, 3, 5]);
+  eq(Z.filter(odd, {}), {});
+  eq(Z.filter(odd, {x: 1, y: 2, z: 3}), {x: 1, z: 3});
+  eq(Z.filter(odd, Nil), Nil);
+  eq(Z.filter(odd, Cons(1, Cons(2, Cons(3, Cons(4, Cons(5, Nil)))))), Cons(1, Cons(3, Cons(5, Nil))));
+  eq(Z.filter(odd, Nothing), Nothing);
+  eq(Z.filter(odd, Just(0)), Nothing);
+  eq(Z.filter(odd, Just(1)), Just(1));
+});
+
+test('reject', function() {
+  eq(Z.reject.length, 2);
+  eq(Z.reject.name, 'reject');
+
+  eq(Z.reject(odd, []), []);
+  eq(Z.reject(odd, [1, 2, 3, 4, 5]), [2, 4]);
+  eq(Z.reject(odd, {}), {});
+  eq(Z.reject(odd, {x: 1, y: 2, z: 3}), {y: 2});
+  eq(Z.reject(odd, Nil), Nil);
+  eq(Z.reject(odd, Cons(1, Cons(2, Cons(3, Cons(4, Cons(5, Nil)))))), Cons(2, Cons(4, Nil)));
+  eq(Z.reject(odd, Nothing), Nothing);
+  eq(Z.reject(odd, Just(0)), Just(0));
+  eq(Z.reject(odd, Just(1)), Nothing);
+});
+
 test('map', function() {
   eq(Z.map.length, 2);
   eq(Z.map.name, 'map');
@@ -1033,29 +1073,6 @@ test('chainRec', function() {
   }
 
   eq(Z.chainRec(Function, stepper, 0)({step: 2, inc: 100}), 30100);
-});
-
-test('filter', function() {
-  eq(Z.filter.length, 2);
-  eq(Z.filter.name, 'filter');
-
-  eq(Z.filter(odd, []), []);
-  eq(Z.filter(odd, [1, 2, 3, 4, 5]), [1, 3, 5]);
-  eq(Z.filter(odd, Nil), Nil);
-  eq(Z.filter(odd, Cons(1, Cons(2, Cons(3, Cons(4, Cons(5, Nil)))))), Cons(1, Cons(3, Cons(5, Nil))));
-});
-
-test('filterM', function() {
-  eq(Z.filterM.length, 2);
-  eq(Z.filterM.name, 'filterM');
-
-  eq(Z.filterM(odd, []), []);
-  eq(Z.filterM(odd, [1, 2, 3, 4, 5]), [1, 3, 5]);
-  eq(Z.filterM(odd, Nil), Nil);
-  eq(Z.filterM(odd, Cons(1, Cons(2, Cons(3, Cons(4, Cons(5, Nil)))))), Cons(1, Cons(3, Cons(5, Nil))));
-  eq(Z.filterM(odd, Nothing), Nothing);
-  eq(Z.filterM(odd, Just(0)), Nothing);
-  eq(Z.filterM(odd, Just(1)), Just(1));
 });
 
 test('alt', function() {


### PR DESCRIPTION
Commit message:

> This commit introduces a new `filter` function which can operate on a value of any filterable type, replacing the circuitously derived `filter` and `filterM` functions, neither of which supported string maps (or many other filterable types).
>
> Before:
>
> ```haskell
> filter :: (Applicative f, Foldable f, Monoid (f a)) => (a -> Boolean, f a) -> f a
> filterM :: (Alternative m, Monad m) => (a -> Boolean, m a) -> m a
> ```
>
> After:
>
> ```haskell
> filter :: Filterable f => (a -> Boolean, f a) -> f a
> ```
>
> This commit also introduces `reject`, the complement of `filter`.
