### PR TITLE
update documentation of ‘takeWhile’ and ‘dropWhile’

### DIFF
--- a/index.js
+++ b/index.js
@@ -1566,6 +1566,54 @@
     return filter(function(x) { return !pred(x); }, filterable);
   }
 
+  //# takeWhile :: Filterable f => (a -> Boolean, f a) -> f a
+  //.
+  //. Discards the first inner value which does not satisfy the predicate, and
+  //. all subsequent inner values.
+  //.
+  //. This function is derived from [`filter`](#filter).
+  //.
+  //. See also [`dropWhile`](#dropWhile).
+  //.
+  //. ```javascript
+  //. > takeWhile(s => /x/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. ['xy', 'xz', 'yx']
+  //.
+  //. > takeWhile(s => /y/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. ['xy']
+  //.
+  //. > takeWhile(s => /z/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. []
+  //. ```
+  function takeWhile(pred, filterable) {
+    var take = true;
+    return filter(function(x) { return take = take && pred(x); }, filterable);
+  }
+
+  //# dropWhile :: Filterable f => (a -> Boolean, f a) -> f a
+  //.
+  //. Retains the first inner value which does not satisfy the predicate, and
+  //. all subsequent inner values.
+  //.
+  //. This function is derived from [`filter`](#filter).
+  //.
+  //. See also [`takeWhile`](#takeWhile).
+  //.
+  //. ```javascript
+  //. > dropWhile(s => /x/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. ['yz', 'zx', 'zy']
+  //.
+  //. > dropWhile(s => /y/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. ['xz', 'yx', 'yz', 'zx', 'zy']
+  //.
+  //. > dropWhile(s => /z/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. ['xy', 'xz', 'yx', 'yz', 'zx', 'zy']
+  //. ```
+  function dropWhile(pred, filterable) {
+    var take = false;
+    return filter(function(x) { return take = take || !pred(x); }, filterable);
+  }
+
   //# map :: Functor f => (a -> b, f a) -> f b
   //.
   //. Function wrapper for [`fantasy-land/map`][].
@@ -2064,56 +2112,6 @@
       result = concat(result, of(F, rs[idx].x));
     }
     return result;
-  }
-
-  //# takeWhile :: (Applicative f, Foldable f, Monoid (f a)) => (a -> Boolean, f a) -> f a
-  //.
-  //. Discards the first inner value which does not satisfy the predicate, and
-  //. all subsequent inner values.
-  //.
-  //. This function is derived from [`concat`](#concat), [`empty`](#empty),
-  //. [`of`](#of), and [`reduce`](#reduce).
-  //.
-  //. See also [`dropWhile`](#dropWhile).
-  //.
-  //. ```javascript
-  //. > takeWhile(s => /x/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
-  //. ['xy', 'xz', 'yx']
-  //.
-  //. > takeWhile(s => /y/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
-  //. ['xy']
-  //.
-  //. > takeWhile(s => /z/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
-  //. []
-  //. ```
-  function takeWhile(pred, foldable) {
-    var take = true;
-    return filter(function(x) { return take = take && pred(x); }, foldable);
-  }
-
-  //# dropWhile :: (Applicative f, Foldable f, Monoid (f a)) => (a -> Boolean, f a) -> f a
-  //.
-  //. Retains the first inner value which does not satisfy the predicate, and
-  //. all subsequent inner values.
-  //.
-  //. This function is derived from [`concat`](#concat), [`empty`](#empty),
-  //. [`of`](#of), and [`reduce`](#reduce).
-  //.
-  //. See also [`takeWhile`](#takeWhile).
-  //.
-  //. ```javascript
-  //. > dropWhile(s => /x/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
-  //. ['yz', 'zx', 'zy']
-  //.
-  //. > dropWhile(s => /y/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
-  //. ['xz', 'yx', 'yz', 'zx', 'zy']
-  //.
-  //. > dropWhile(s => /z/.test(s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
-  //. ['xy', 'xz', 'yx', 'yz', 'zx', 'zy']
-  //. ```
-  function dropWhile(pred, foldable) {
-    var take = false;
-    return filter(function(x) { return take = take || !pred(x); }, foldable);
   }
 
   //# traverse :: (Applicative f, Traversable t) => (TypeRep f, a -> f b, t a) -> f (t b)

--- a/test/index.js
+++ b/test/index.js
@@ -893,6 +893,42 @@ test('reject', function() {
   eq(Z.reject(odd, Just(1)), Nothing);
 });
 
+test('takeWhile', function() {
+  eq(Z.takeWhile.length, 2);
+  eq(Z.takeWhile.name, 'takeWhile');
+
+  eq(Z.takeWhile(odd, []), []);
+  eq(Z.takeWhile(odd, [1]), [1]);
+  eq(Z.takeWhile(odd, [1, 3]), [1, 3]);
+  eq(Z.takeWhile(odd, [1, 3, 6]), [1, 3]);
+  eq(Z.takeWhile(odd, [1, 3, 6, 10]), [1, 3]);
+  eq(Z.takeWhile(odd, [1, 3, 6, 10, 15]), [1, 3]);
+  eq(Z.takeWhile(odd, Nil), Nil);
+  eq(Z.takeWhile(odd, Cons(1, Nil)), Cons(1, Nil));
+  eq(Z.takeWhile(odd, Cons(1, Cons(3, Nil))), Cons(1, Cons(3, Nil)));
+  eq(Z.takeWhile(odd, Cons(1, Cons(3, Cons(6, Nil)))), Cons(1, Cons(3, Nil)));
+  eq(Z.takeWhile(odd, Cons(1, Cons(3, Cons(6, Cons(10, Nil))))), Cons(1, Cons(3, Nil)));
+  eq(Z.takeWhile(odd, Cons(1, Cons(3, Cons(6, Cons(10, Cons(15, Nil)))))), Cons(1, Cons(3, Nil)));
+});
+
+test('dropWhile', function() {
+  eq(Z.dropWhile.length, 2);
+  eq(Z.dropWhile.name, 'dropWhile');
+
+  eq(Z.dropWhile(odd, []), []);
+  eq(Z.dropWhile(odd, [1]), []);
+  eq(Z.dropWhile(odd, [1, 3]), []);
+  eq(Z.dropWhile(odd, [1, 3, 6]), [6]);
+  eq(Z.dropWhile(odd, [1, 3, 6, 10]), [6, 10]);
+  eq(Z.dropWhile(odd, [1, 3, 6, 10, 15]), [6, 10, 15]);
+  eq(Z.dropWhile(odd, Nil), Nil);
+  eq(Z.dropWhile(odd, Cons(1, Nil)), Nil);
+  eq(Z.dropWhile(odd, Cons(1, Cons(3, Nil))), Nil);
+  eq(Z.dropWhile(odd, Cons(1, Cons(3, Cons(6, Nil)))), Cons(6, Nil));
+  eq(Z.dropWhile(odd, Cons(1, Cons(3, Cons(6, Cons(10, Nil))))), Cons(6, Cons(10, Nil)));
+  eq(Z.dropWhile(odd, Cons(1, Cons(3, Cons(6, Cons(10, Cons(15, Nil)))))), Cons(6, Cons(10, Cons(15, Nil))));
+});
+
 test('map', function() {
   eq(Z.map.length, 2);
   eq(Z.map.name, 'map');
@@ -1196,42 +1232,6 @@ test('sortBy', function() {
   eq(Z.sortBy(rank, [_7s, _5s, _2h, _5h]), [_2h, _5s, _5h, _7s]);
   eq(Z.sortBy(suit, [_7s, _5h, _2h, _5s]), [_5h, _2h, _7s, _5s]);
   eq(Z.sortBy(suit, [_5s, _2h, _5h, _7s]), [_2h, _5h, _5s, _7s]);
-});
-
-test('takeWhile', function() {
-  eq(Z.takeWhile.length, 2);
-  eq(Z.takeWhile.name, 'takeWhile');
-
-  eq(Z.takeWhile(odd, []), []);
-  eq(Z.takeWhile(odd, [1]), [1]);
-  eq(Z.takeWhile(odd, [1, 3]), [1, 3]);
-  eq(Z.takeWhile(odd, [1, 3, 6]), [1, 3]);
-  eq(Z.takeWhile(odd, [1, 3, 6, 10]), [1, 3]);
-  eq(Z.takeWhile(odd, [1, 3, 6, 10, 15]), [1, 3]);
-  eq(Z.takeWhile(odd, Nil), Nil);
-  eq(Z.takeWhile(odd, Cons(1, Nil)), Cons(1, Nil));
-  eq(Z.takeWhile(odd, Cons(1, Cons(3, Nil))), Cons(1, Cons(3, Nil)));
-  eq(Z.takeWhile(odd, Cons(1, Cons(3, Cons(6, Nil)))), Cons(1, Cons(3, Nil)));
-  eq(Z.takeWhile(odd, Cons(1, Cons(3, Cons(6, Cons(10, Nil))))), Cons(1, Cons(3, Nil)));
-  eq(Z.takeWhile(odd, Cons(1, Cons(3, Cons(6, Cons(10, Cons(15, Nil)))))), Cons(1, Cons(3, Nil)));
-});
-
-test('dropWhile', function() {
-  eq(Z.dropWhile.length, 2);
-  eq(Z.dropWhile.name, 'dropWhile');
-
-  eq(Z.dropWhile(odd, []), []);
-  eq(Z.dropWhile(odd, [1]), []);
-  eq(Z.dropWhile(odd, [1, 3]), []);
-  eq(Z.dropWhile(odd, [1, 3, 6]), [6]);
-  eq(Z.dropWhile(odd, [1, 3, 6, 10]), [6, 10]);
-  eq(Z.dropWhile(odd, [1, 3, 6, 10, 15]), [6, 10, 15]);
-  eq(Z.dropWhile(odd, Nil), Nil);
-  eq(Z.dropWhile(odd, Cons(1, Nil)), Nil);
-  eq(Z.dropWhile(odd, Cons(1, Cons(3, Nil))), Nil);
-  eq(Z.dropWhile(odd, Cons(1, Cons(3, Cons(6, Nil)))), Cons(6, Nil));
-  eq(Z.dropWhile(odd, Cons(1, Cons(3, Cons(6, Cons(10, Nil))))), Cons(6, Cons(10, Nil)));
-  eq(Z.dropWhile(odd, Cons(1, Cons(3, Cons(6, Cons(10, Cons(15, Nil)))))), Cons(6, Cons(10, Cons(15, Nil))));
 });
 
 test('traverse', function() {


### PR DESCRIPTION
I extracted these changes from #82 as I'd like to include them in a patch release before merging sanctuary-js/sanctuary#475. @gabejohnson is listed as the author. I made one additional change: moving the definitions of `takeWhile` and `dropWhile` alongside those of `filter` and `reject`.
