### PR TITLE
fix handling of NaN in Number$prototype$lte to guarantee totality

### DIFF
--- a/index.js
+++ b/index.js
@@ -668,7 +668,7 @@
   function Number$prototype$lte(other) {
     return typeof this === 'object' ?
       lte(this.valueOf(), other.valueOf()) :
-      isNaN(this) && isNaN(other) || this <= other;
+      isNaN(this) || this <= other;
   }
 
   //  Date$prototype$toString :: Date ~> () -> String

--- a/test/index.js
+++ b/test/index.js
@@ -683,7 +683,7 @@ test('lte', function() {
   eq(Z.lte(Infinity, -Infinity), false);
   eq(Z.lte(-Infinity, Infinity), true);
   eq(Z.lte(-Infinity, -Infinity), true);
-  eq(Z.lte(NaN, Math.PI), false);
+  eq(Z.lte(NaN, Math.PI), true);
   eq(Z.lte(Math.PI, NaN), false);
   eq(Z.lte(new Number(0), new Number(0)), true);
   eq(Z.lte(new Number(0), new Number(-0)), true);
@@ -694,7 +694,7 @@ test('lte', function() {
   eq(Z.lte(new Number(Infinity), new Number(-Infinity)), false);
   eq(Z.lte(new Number(-Infinity), new Number(Infinity)), true);
   eq(Z.lte(new Number(-Infinity), new Number(-Infinity)), true);
-  eq(Z.lte(new Number(NaN), new Number(Math.PI)), false);
+  eq(Z.lte(new Number(NaN), new Number(Math.PI)), true);
   eq(Z.lte(new Number(Math.PI), new Number(NaN)), false);
   eq(Z.lte(42, new Number(42)), false);
   eq(Z.lte(new Number(42), 42), false);


### PR DESCRIPTION
Currently, `Z.lte(NaN, 0)` and `Z.lte(0, NaN)` both evaluate `false`, violating the totality law.

I arbitrarily decided to make `NaN` the “smallest” `Number` value.

/cc @CrossEye
