### PR TITLE
Improve performance of sortBy

### DIFF
--- a/bench/old-vs-new.js
+++ b/bench/old-vs-new.js
@@ -1,12 +1,14 @@
 'use strict';
 
+var L = require('list/fantasy-land');
 var benchmark = require('sanctuary-benchmark');
 
 var oldZ = require('sanctuary-type-classes');
 var newZ = require('..');
 
-
 var Identity = require('../test/Identity');
+var shuffle = require('../test/shuffle');
+
 
 //  inc :: Number -> Number
 function inc(x) {
@@ -18,6 +20,14 @@ function prep(specs) {
   return newZ.map(function(f) { return [{}, f]; }, specs);
 }
 
+var shuffledArray = (function() {
+  var xs = [];
+  for (var x = 0; x < 5000; x += 1) xs.push(x);
+  shuffle(xs);
+  return xs;
+}());
+var shuffledList = L.fromArray(shuffledArray);
+
 module.exports = benchmark(oldZ, newZ, {leftHeader: 'old', rightHeader: 'new'}, prep({
   'functions.of.Array':          function(Z) { Z.of(Array, 42); },
   'functions.of.Identity':       function(Z) { Z.of(Identity, 42); },
@@ -25,6 +35,8 @@ module.exports = benchmark(oldZ, newZ, {leftHeader: 'old', rightHeader: 'new'}, 
   'methods.equals.Object':       function(Z) { Z.equals({x: 0, y: 0}, {y: 0, x: 0}); },
   'methods.map.Array':           function(Z) { Z.map(inc, [1, 2, 3]); },
   'methods.map.Identity':        function(Z) { Z.map(inc, Identity(1)); },
+  'methods.sort.Array':          function(Z) { Z.sort(shuffledArray); },
+  'methods.sort.List':           function(Z) { Z.sort(shuffledList); },
   'methods.toString.Identity':   function(Z) { Z.toString(Identity(0)); },
   'methods.toString.Object':     function(Z) { Z.toString({x: 0, y: 0}); },
   'methods.toString.String':     function(Z) { Z.toString('hello'); },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "fantasy-land": "3.5.0",
+    "list": "2.0.11",
     "sanctuary-benchmark": "1.0.x",
     "sanctuary-scripts": "1.5.x"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1233,6 +1233,8 @@ test('sort', function() {
     eq(Z.sort(Cons('foo', Nil)), Cons('foo', Nil));
     eq(Z.sort(Cons('foo', Cons('bar', Nil))), Cons('bar', Cons('foo', Nil)));
     eq(Z.sort(Cons('foo', Cons('bar', Cons('baz', Nil)))), Cons('bar', Cons('baz', Cons('foo', Nil))));
+    eq(Z.sort([NaN, 3, NaN, 1, NaN, 2, NaN]), [NaN, NaN, NaN, NaN, 1, 2, 3]);
+    eq(Z.sort([Just(3), Just(1), Just(2)]), [Just(1), Just(2), Just(3)]);
   }
 
   runAssertions();

--- a/test/shuffle.js
+++ b/test/shuffle.js
@@ -1,0 +1,13 @@
+'use strict';
+
+//  https://en.wikipedia.org/wiki/Fisher–Yates_shuffle
+
+//  shuffle :: Array a -> Undefined
+module.exports = function(xs) {
+  for (var i = xs.length - 1; i > 0; i -= 1) {
+    var j = Math.floor(Math.random() * (i + 1));
+    var x = xs[i];
+    xs[i] = xs[j];
+    xs[j] = x;
+  }
+};


### PR DESCRIPTION
This PR improves the performance of `sortBy` and thus also `sort`. These are the benchmark results I get when running `sort` on an array of 100 numbers.

```
┌───────────────────────┬────────────────────┬──────────────────────┬────────┬───────────┬───┐
│ suite                 │ old                │ new                  │ diff   │ change    │ α │
├───────────────────────┼────────────────────┼──────────────────────┼────────┼───────────┼───┤
│ methods.sort.Array    │ 3 Hz ±1.49% (n 12) │ 637 Hz ±0.30% (n 89) │ 099.1% │ +21464.1% │ ✓ │
├───────────────────────┼────────────────────┼──────────────────────┼────────┼───────────┼───┤
│ methods.sort.Foldable │ 4 Hz ±0.99% (n 14) │ 317 Hz ±0.45% (n 82) │ 097.7% │ +8503.4%  │ ✓ │
└───────────────────────┴────────────────────┴──────────────────────┴────────┴───────────┴───┘
```

In this case sorting an array got 214 times faster and sorting a foldable (using List as the benchmark subject) got 85 times faster :smile: 

Note however that to achieve the performance increase I had to use fewer sanctuary-type-class functions internally in the implementation of `sortBy`. It seems that using sanctuary-type-class functions results in some overhead. I created two benchmarks to try and measure the overhead of the functions used inside `sortBy`.
```
var test = R.range(0, 100);
// ...
'methods.test.reduceMin':     function(Z) { Z.reduce(Z.min, 0, test); },
'methods.test.append':        function(Z) { Z.reduce((a, b) => Z.append(b, a), [], [0, 1, 2, 3, 4]); },
```
Then I plugged in Ramda and sanctuary-type-class in the above benchmarks and got the following results:
```
┌───────────────────────┬──────────────────────────┬────────────────────────────┬────────┬───────────┬───┐
│ suite                 │ sanctuary-type-classes   │ Ramda                      │ diff   │ change    │ α │
├───────────────────────┼──────────────────────────┼────────────────────────────┼────────┼───────────┼───┤
│ methods.test.reduceMin│ 2,073 Hz ±0.52% (n 89)   │ 504,551 Hz ±0.37% (n 93)   │ 099.2% │ +24235.2% │ ✓ │
├───────────────────────┼──────────────────────────┼────────────────────────────┼────────┼───────────┼───┤
│ methods.test.append   │ 235,364 Hz ±1.02% (n 87) │ 1,022,981 Hz ±0.46% (n 91) │ 062.6% │ +334.6%   │ ✓ │
└───────────────────────┴──────────────────────────┴────────────────────────────┴────────┴───────────┴───┘
```
Getting the minimum of an array of 100 numbers seems to be 242 times as slow with sanctuary-type-classes and creating an array of size 5 by prepending is about 3.3 times slower than Ramda. `Z.lte` in particular seems to be be slow and it is still used inside `sortBy` in some cases and in these cases `sortBy` is still slow due to `Z.lte` ending up as the bottleneck.