### PR TITLE
assert that ‘sort’ and ‘sortBy’ do not rely on Array#sort being stable

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,7 @@ var Maybe = require('./Maybe');
 var Sum = require('./Sum');
 var Tuple = require('./Tuple');
 var eq = require('./eq');
+var withUnstableArraySort = require('./quicksort').withUnstableArraySort;
 
 
 var Nil = List.Nil;
@@ -1215,14 +1216,19 @@ test('sort', function() {
   eq(Z.sort.length, 1);
   eq(Z.sort.name, 'sort');
 
-  eq(Z.sort([]), []);
-  eq(Z.sort(['foo']), ['foo']);
-  eq(Z.sort(['foo', 'bar']), ['bar', 'foo']);
-  eq(Z.sort(['foo', 'bar', 'baz']), ['bar', 'baz', 'foo']);
-  eq(Z.sort(Nil), Nil);
-  eq(Z.sort(Cons('foo', Nil)), Cons('foo', Nil));
-  eq(Z.sort(Cons('foo', Cons('bar', Nil))), Cons('bar', Cons('foo', Nil)));
-  eq(Z.sort(Cons('foo', Cons('bar', Cons('baz', Nil)))), Cons('bar', Cons('baz', Cons('foo', Nil))));
+  function runAssertions() {
+    eq(Z.sort([]), []);
+    eq(Z.sort(['foo']), ['foo']);
+    eq(Z.sort(['foo', 'bar']), ['bar', 'foo']);
+    eq(Z.sort(['foo', 'bar', 'baz']), ['bar', 'baz', 'foo']);
+    eq(Z.sort(Nil), Nil);
+    eq(Z.sort(Cons('foo', Nil)), Cons('foo', Nil));
+    eq(Z.sort(Cons('foo', Cons('bar', Nil))), Cons('bar', Cons('foo', Nil)));
+    eq(Z.sort(Cons('foo', Cons('bar', Cons('baz', Nil)))), Cons('bar', Cons('baz', Cons('foo', Nil))));
+  }
+
+  runAssertions();
+  withUnstableArraySort(runAssertions);
 });
 
 test('sortBy', function() {
@@ -1235,10 +1241,16 @@ test('sortBy', function() {
   var _5h = {rank: 5, suit: 'h'};
   var _2h = {rank: 2, suit: 'h'};
   var _5s = {rank: 5, suit: 's'};
-  eq(Z.sortBy(rank, [_7s, _5h, _2h, _5s]), [_2h, _5h, _5s, _7s]);
-  eq(Z.sortBy(rank, [_7s, _5s, _2h, _5h]), [_2h, _5s, _5h, _7s]);
-  eq(Z.sortBy(suit, [_7s, _5h, _2h, _5s]), [_5h, _2h, _7s, _5s]);
-  eq(Z.sortBy(suit, [_5s, _2h, _5h, _7s]), [_2h, _5h, _5s, _7s]);
+
+  function runAssertions() {
+    eq(Z.sortBy(rank, [_7s, _5h, _2h, _5s]), [_2h, _5h, _5s, _7s]);
+    eq(Z.sortBy(rank, [_7s, _5s, _2h, _5h]), [_2h, _5s, _5h, _7s]);
+    eq(Z.sortBy(suit, [_7s, _5h, _2h, _5s]), [_5h, _2h, _7s, _5s]);
+    eq(Z.sortBy(suit, [_5s, _2h, _5h, _7s]), [_2h, _5h, _5s, _7s]);
+  }
+
+  runAssertions();
+  withUnstableArraySort(runAssertions);
 });
 
 test('traverse', function() {

--- a/test/quicksort.js
+++ b/test/quicksort.js
@@ -1,0 +1,49 @@
+'use strict';
+
+//  https://en.wikipedia.org/wiki/Quicksort#Hoare_partition_scheme
+
+//  quicksort :: (Array a, (a, a) -> Number, Integer, Integer) -> Undefined
+function quicksort(xs, cmp, lo, hi) {
+  if (lo < hi) {
+    var idx = partition(xs, cmp, lo, hi);
+    quicksort(xs, cmp, lo, idx);
+    quicksort(xs, cmp, idx + 1, hi);
+  }
+}
+
+//  partition :: (Array a, (a, a) -> Number, Integer, Integer) -> Integer
+function partition(xs, cmp, lo, hi) {
+  var pivot = xs[lo];
+  var i = lo - 1;
+  var j = hi + 1;
+  while (true) {
+    do i += 1; while (cmp(xs[i], pivot) < 0);
+    do j -= 1; while (cmp(xs[j], pivot) > 0);
+
+    if (i >= j) return j;
+
+    var x = xs[i];
+    xs[i] = xs[j];
+    xs[j] = x;
+  }
+}
+
+//  defaultComparator :: (a, a) -> Number
+function defaultComparator(x, y) {
+  return x < y ? -1 : x > y ? 1 : 0;
+}
+
+//  withUnstableArraySort :: (() -> Undefined) -> Undefined
+exports.withUnstableArraySort = function(thunk) {
+  var Array$prototype$sort = Array.prototype.sort;
+  Array.prototype.sort = function(_cmp) {
+    var cmp = arguments.length < 1 ? defaultComparator : _cmp;
+    quicksort(this, cmp, 0, this.length - 1);
+    return this;
+  };
+  try {
+    thunk();
+  } finally {
+    Array.prototype.sort = Array$prototype$sort;
+  }
+};


### PR DESCRIPTION
While working on #92 I realized I could replace `idx: rs.length` with `idx: 0` and all the tests would still pass. This is because `Array#sort` is stable in my environment, as it is in most environments. The language specification does not guarantee this, though, so we should not assume it.

This pull request introduces a function, `withUnstableArraySort`, which monkey patches `Array#sort`, evaluates a thunk, then restores `Array#sort` to its prior value. Any change to `Z.sort` or `Z.sortBy` which assumes `Array#sort` to be stable will pass tests in the default environment but will fail some tests in the modified environment.

/cc @paldepind
