### PR TITLE
remove uses of Function#apply to accommodate large arrays

### DIFF
--- a/bench/old-vs-new.js
+++ b/bench/old-vs-new.js
@@ -10,6 +10,16 @@ var Identity = require('../test/Identity');
 var shuffle = require('../test/shuffle');
 
 
+//  chainRecArrayNumber :: (Number -> c, Number -> c, Number) -> Array c
+function chainRecArrayNumber(next, done, x) {
+  return [done(x), (x <= 1 ? done : next)(x - 1)];
+}
+
+//  double :: a -> Array2 a a
+function double(x) {
+  return [x, x];
+}
+
 //  inc :: Number -> Number
 function inc(x) {
   return x + 1;
@@ -29,8 +39,10 @@ var shuffledArray = (function() {
 var shuffledList = L.fromArray(shuffledArray);
 
 module.exports = benchmark(oldZ, newZ, {leftHeader: 'old', rightHeader: 'new'}, prep({
+  'functions.chainRec.Array':    function(Z) { Z.chainRec(Array, chainRecArrayNumber, 100); },
   'functions.of.Array':          function(Z) { Z.of(Array, 42); },
   'functions.of.Identity':       function(Z) { Z.of(Identity, 42); },
+  'methods.chain.Array':         function(Z) { Z.chain(double, shuffledArray); },
   'methods.equals.Identity':     function(Z) { Z.equals(Identity(0), Identity(0)); },
   'methods.equals.Object':       function(Z) { Z.equals({x: 0, y: 0}, {y: 0, x: 0}); },
   'methods.map.Array':           function(Z) { Z.map(inc, [1, 2, 3]); },

--- a/index.js
+++ b/index.js
@@ -747,17 +747,27 @@
 
   //  Array$chainRec :: ((a -> c, b -> c, a) -> Array c, a) -> Array b
   function Array$chainRec(f, x) {
-    var $todo = [x];
-    var $done = [];
-    while ($todo.length > 0) {
-      var xs = f(iterationNext, iterationDone, $todo.shift());
-      var $more = [];
-      for (var idx = 0; idx < xs.length; idx += 1) {
-        (xs[idx].done ? $done : $more).push(xs[idx].value);
+    var result = [];
+    var nil = {};
+    var todo = {head: x, tail: nil};
+    while (todo !== nil) {
+      var more = nil;
+      var steps = f(iterationNext, iterationDone, todo.head);
+      for (var idx = 0; idx < steps.length; idx += 1) {
+        var step = steps[idx];
+        if (step.done) {
+          result.push(step.value);
+        } else {
+          more = {head: step.value, tail: more};
+        }
       }
-      Array.prototype.unshift.apply($todo, $more);
+      todo = todo.tail;
+      while (more !== nil) {
+        todo = {head: more.head, tail: todo};
+        more = more.tail;
+      }
     }
-    return $done;
+    return result;
   }
 
   //  Array$zero :: () -> Array a
@@ -825,7 +835,11 @@
   //  Array$prototype$chain :: Array a ~> (a -> Array b) -> Array b
   function Array$prototype$chain(f) {
     var result = [];
-    this.forEach(function(x) { Array.prototype.push.apply(result, f(x)); });
+    for (var idx = 0; idx < this.length; idx += 1) {
+      for (var idx2 = 0, xs = f(this[idx]); idx2 < xs.length; idx2 += 1) {
+        result.push(xs[idx2]);
+      }
+    }
     return result;
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -1177,6 +1177,7 @@ test('chain', function() {
   eq(Z.chain(repeat, abs)(-3), [-3, -3, -3]);
   eq(Z.chain(identInc, Identity(42)), Identity(43));
   eq(Z.chain(identity, Identity(Identity(0))), Identity(0));
+  eq(Z.chain(identity, [new Array(1e6).join('x').split('')]).length, 999999);
 });
 
 test('join', function() {
@@ -1217,6 +1218,8 @@ test('chainRec', function() {
   }
 
   eq(Z.chainRec(Function, stepper, 0)({step: 2, inc: 100}), 30100);
+
+  eq(Z.chainRec(Array, function(next, done, n) { return n === 0 ? [done(0)] : Z.map(next, repeat(n)(0)); }, 1e6).length, 1e6);
 });
 
 test('alt', function() {


### PR DESCRIPTION
Supersedes #102

The new implementation of `Array$chainRec` is longer but arguably simpler and more efficient.

<table>
  <tr>
    <td colspan="2"><b>Before</b></td>
  </tr>
  <tr>
    <td>Data structure</td>
    <td>array</td>
  </tr>
  <tr>
    <td>Loop condition</td>
    <td><code>$todo.length > 0</code></td>
  </tr>
  <tr>
    <td>Advancement</td>
    <td><code>$todo.shift()</code></td>
  </tr>
  <tr>
    <td>Accumulation</td>
    <td><code>$more.push(step.value)</code></td>
  </tr>
  <tr>
    <td>Transference</td>
    <td><code>Array.prototype.unshift.apply($todo, $more)</code> :warning:</td>
  </tr>
  <tr>
    <td colspan="2"><b>After</b></td>
  </tr>
  <tr>
    <td>Data structure</td>
    <td>linked list</td>
  </tr>
  <tr>
    <td>Loop condition</td>
    <td><code>xs !== nil</code></td>
  </tr>
  <tr>
    <td>Advancement</td>
    <td><code>xs = xs.tail</code></td>
  </tr>
  <tr>
    <td>Accumulation</td>
    <td><code>sx = {head: step.value, tail: sx}</code></td>
  </tr>
  <tr>
    <td>Transference</td>
    <td><code>while (sx !== nil) { xs = {head: sx.head, tail: xs}; sx = sx.tail; }</code></td>
  </tr>
</table>

I'd appreciate your :eyes: on this pull request, Irakli. :)

/cc @edahlseng
