### PR TITLE
replace ‘Pair a b’ with ‘Array2 a b’ in type signatures

### DIFF
--- a/bench/old-vs-new.js
+++ b/bench/old-vs-new.js
@@ -15,7 +15,7 @@ function inc(x) {
   return x + 1;
 }
 
-//  prep :: StrMap Function -> StrMap (Pair (StrMap a) Function)
+//  prep :: StrMap Function -> StrMap (Array2 (StrMap a) Function)
 function prep(specs) {
   return newZ.map(function(f) { return [{}, f]; }, specs);
 }

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@
   //  identity :: a -> a
   function identity(x) { return x; }
 
-  //  pair :: a -> b -> Pair a b
+  //  pair :: a -> b -> Array2 a b
   function pair(x) {
     return function(y) {
       return [x, y];
@@ -1253,7 +1253,7 @@
   //. false
   //. ```
   var equals = (function() {
-    //  $pairs :: Array (Pair Any Any)
+    //  $pairs :: Array (Array2 Any Any)
     var $pairs = [];
 
     return function equals(x, y) {
@@ -1324,7 +1324,7 @@
   //. false
   //. ```
   var lte = (function() {
-    //  $pairs :: Array (Pair Any Any)
+    //  $pairs :: Array (Array2 Any Any)
     var $pairs = [];
 
     return function lte(x, y) {

--- a/test/index.js
+++ b/test/index.js
@@ -99,7 +99,7 @@ function concat(xs) {
   };
 }
 
-//  double :: a -> Pair a a
+//  double :: a -> Array2 a a
 function double(x) {
   eq(arguments.length, double.length);
   return [x, x];
@@ -175,10 +175,10 @@ function odd(x) {
   return x % 2 === 1;
 }
 
-//  ones :: Pair Number (Pair Number (Pair Number ...))
+//  ones :: Array2 Number (Array2 Number (Array2 Number ...))
 var ones = [1]; ones.push(ones);
 
-//  ones_ :: Pair Number (Pair Number (Pair Number ...))
+//  ones_ :: Array2 Number (Array2 Number (Array2 Number ...))
 var ones_ = [1]; ones_.push([1, ones_]);
 
 //  parseInt_ :: Integer -> String -> Maybe Integer


### PR DESCRIPTION
This reflects the change made in sanctuary-js/sanctuary-def#182.
