### PR TITLE
derive ‘clamp’ from ‘min’ and ‘max’

### DIFF
--- a/index.js
+++ b/index.js
@@ -1332,6 +1332,27 @@
     return lte (x, y) ? y : x;
   }
 
+  //# clamp :: Ord a => (a, a, a) -> a
+  //.
+  //. Takes a lower bound, an upper bound, and a value of the same type.
+  //. Returns the value if it is within the bounds; the nearer bound otherwise.
+  //.
+  //. This function is derived from [`min`](#min) and [`max`](#max).
+  //.
+  //. ```javascript
+  //. > clamp (0, 100, 42)
+  //. 42
+  //.
+  //. > clamp (0, 100, -1)
+  //. 0
+  //.
+  //. > clamp ('A', 'Z', '~')
+  //. 'Z'
+  //. ```
+  function clamp(lower, upper, x) {
+    return max (lower, min (upper, x));
+  }
+
   //# compose :: Semigroupoid c => (c j k, c i j) -> c i k
   //.
   //. Function wrapper for [`fantasy-land/compose`][].
@@ -2247,6 +2268,7 @@
     gte: gte,
     min: min,
     max: max,
+    clamp: clamp,
     compose: compose,
     id: id,
     concat: concat,

--- a/test/index.js
+++ b/test/index.js
@@ -834,6 +834,22 @@ test ('max', function() {
   eq (Z.max (['x', 'x'], ['x']), ['x', 'x']);
 });
 
+test ('clamp', function() {
+  eq (Z.clamp.length, 3);
+  eq (Z.clamp.name, 'clamp');
+
+  eq (Z.clamp (0, 100, -1), 0);
+  eq (Z.clamp (0, 100, 0), 0);
+  eq (Z.clamp (0, 100, 50), 50);
+  eq (Z.clamp (0, 100, 100), 100);
+  eq (Z.clamp (0, 100, 101), 100);
+  eq (Z.clamp ('A', 'Z', '0'), 'A');
+  eq (Z.clamp ('A', 'Z', 'A'), 'A');
+  eq (Z.clamp ('A', 'Z', 'X'), 'X');
+  eq (Z.clamp ('A', 'Z', 'Z'), 'Z');
+  eq (Z.clamp ('A', 'Z', '~'), 'Z');
+});
+
 test ('compose', function() {
   eq (Z.compose.length, 2);
   eq (Z.compose.name, 'compose');


### PR DESCRIPTION
This addition was proposed in sanctuary-js/sanctuary#574.

/cc @Fl4m3Ph03n1x, @Bradcomp
