### PR TITLE
reformulate ‘takeWhile’ and ‘dropWhile’

### DIFF
--- a/index.js
+++ b/index.js
@@ -1512,6 +1512,74 @@
     return filter (function(x) { return !(pred (x)); }, filterable);
   }
 
+  //# takeWhile :: (Applicative f, Foldable f, Monoid (f a)) => (a -> Boolean, f a) -> f a
+  //.
+  //. Discards the first element which does not satisfy the predicate, and all
+  //. subsequent elements.
+  //.
+  //. This function is derived from [`concat`](#concat), [`empty`](#empty),
+  //. [`of`](#of), and [`reduce`](#reduce).
+  //.
+  //. See also [`dropWhile`](#dropWhile).
+  //.
+  //. ```javascript
+  //. > takeWhile (s => /x/.test (s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. ['xy', 'xz', 'yx']
+  //.
+  //. > takeWhile (s => /y/.test (s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. ['xy']
+  //.
+  //. > takeWhile (s => /z/.test (s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. []
+  //. ```
+  function takeWhile(pred, foldable) {
+    //  Fast path for arrays.
+    if (Array.isArray (foldable)) {
+      var idx = 0;
+      while (idx < foldable.length && pred (foldable[idx])) idx += 1;
+      return foldable.slice (0, idx);
+    }
+    var F = foldable.constructor;
+    return (reduce (function(acc, x) {
+      var take = acc.take && pred (x);
+      return {take: take, xs: take ? concat (acc.xs, of (F, x)) : acc.xs};
+    }, {take: true, xs: empty (F)}, foldable)).xs;
+  }
+
+  //# dropWhile :: (Applicative f, Foldable f, Monoid (f a)) => (a -> Boolean, f a) -> f a
+  //.
+  //. Retains the first element which does not satisfy the predicate, and all
+  //. subsequent elements.
+  //.
+  //. This function is derived from [`concat`](#concat), [`empty`](#empty),
+  //. [`of`](#of), and [`reduce`](#reduce).
+  //.
+  //. See also [`takeWhile`](#takeWhile).
+  //.
+  //. ```javascript
+  //. > dropWhile (s => /x/.test (s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. ['yz', 'zx', 'zy']
+  //.
+  //. > dropWhile (s => /y/.test (s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. ['xz', 'yx', 'yz', 'zx', 'zy']
+  //.
+  //. > dropWhile (s => /z/.test (s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
+  //. ['xy', 'xz', 'yx', 'yz', 'zx', 'zy']
+  //. ```
+  function dropWhile(pred, foldable) {
+    //  Fast path for arrays.
+    if (Array.isArray (foldable)) {
+      var idx = 0;
+      while (idx < foldable.length && pred (foldable[idx])) idx += 1;
+      return foldable.slice (idx);
+    }
+    var F = foldable.constructor;
+    return (reduce (function(acc, x) {
+      var drop = acc.drop && pred (x);
+      return {drop: drop, xs: drop ? acc.xs : concat (acc.xs, of (F, x))};
+    }, {drop: true, xs: empty (F)}, foldable)).xs;
+  }
+
   //# map :: Functor f => (a -> b, f a) -> f b
   //.
   //. Function wrapper for [`fantasy-land/map`][].
@@ -2302,6 +2370,8 @@
     invert: invert,
     filter: filter,
     reject: reject,
+    takeWhile: takeWhile,
+    dropWhile: dropWhile,
     map: map,
     flip: flip,
     bimap: bimap,

--- a/test/index.js
+++ b/test/index.js
@@ -943,6 +943,42 @@ test ('reject', function() {
   eq (Z.reject (odd, Just (1)), Nothing);
 });
 
+test ('takeWhile', function() {
+  eq (Z.takeWhile.length, 2);
+  eq (Z.takeWhile.name, 'takeWhile');
+
+  eq (Z.takeWhile (odd, []), []);
+  eq (Z.takeWhile (odd, [1]), [1]);
+  eq (Z.takeWhile (odd, [1, 3]), [1, 3]);
+  eq (Z.takeWhile (odd, [1, 3, 6]), [1, 3]);
+  eq (Z.takeWhile (odd, [1, 3, 6, 10]), [1, 3]);
+  eq (Z.takeWhile (odd, [1, 3, 6, 10, 15]), [1, 3]);
+  eq (Z.takeWhile (odd, Nil), Nil);
+  eq (Z.takeWhile (odd, Cons (1, Nil)), Cons (1, Nil));
+  eq (Z.takeWhile (odd, Cons (1, Cons (3, Nil))), Cons (1, Cons (3, Nil)));
+  eq (Z.takeWhile (odd, Cons (1, Cons (3, Cons (6, Nil)))), Cons (1, Cons (3, Nil)));
+  eq (Z.takeWhile (odd, Cons (1, Cons (3, Cons (6, Cons (10, Nil))))), Cons (1, Cons (3, Nil)));
+  eq (Z.takeWhile (odd, Cons (1, Cons (3, Cons (6, Cons (10, Cons (15, Nil)))))), Cons (1, Cons (3, Nil)));
+});
+
+test ('dropWhile', function() {
+  eq (Z.dropWhile.length, 2);
+  eq (Z.dropWhile.name, 'dropWhile');
+
+  eq (Z.dropWhile (odd, []), []);
+  eq (Z.dropWhile (odd, [1]), []);
+  eq (Z.dropWhile (odd, [1, 3]), []);
+  eq (Z.dropWhile (odd, [1, 3, 6]), [6]);
+  eq (Z.dropWhile (odd, [1, 3, 6, 10]), [6, 10]);
+  eq (Z.dropWhile (odd, [1, 3, 6, 10, 15]), [6, 10, 15]);
+  eq (Z.dropWhile (odd, Nil), Nil);
+  eq (Z.dropWhile (odd, Cons (1, Nil)), Nil);
+  eq (Z.dropWhile (odd, Cons (1, Cons (3, Nil))), Nil);
+  eq (Z.dropWhile (odd, Cons (1, Cons (3, Cons (6, Nil)))), Cons (6, Nil));
+  eq (Z.dropWhile (odd, Cons (1, Cons (3, Cons (6, Cons (10, Nil))))), Cons (6, Cons (10, Nil)));
+  eq (Z.dropWhile (odd, Cons (1, Cons (3, Cons (6, Cons (10, Cons (15, Nil)))))), Cons (6, Cons (10, Cons (15, Nil))));
+});
+
 test ('map', function() {
   eq (Z.map.length, 2);
   eq (Z.map.name, 'map');


### PR DESCRIPTION
Commit message:

> Defining these functions in terms of `filter` is unsound: it relies on `fantasy-land/filter` enumeration order, which is unspecified.

[Gitter comment][1]:

> I noticed that making the implementation of `List#fantasy-land/filter` more efficient by reversing the list then filtering while reversing a second time actually broke `takeWhile` and `dropWhile`, as these functions rely on the order in which elements are filtered. Fantasy Land does not require that filtering happen in a particular order (nor should it). Furthermore, there are types (such as `Set a`) which can support `filter` but which cannot sensibly support `takeWhile` and `dropWhile`.



[1]: https://gitter.im/sanctuary-js/sanctuary?at=5c8feec08126720abc042faf
