### PR TITLE
remove ‘takeWhile’ and ‘dropWhile’

### DIFF
--- a/index.js
+++ b/index.js
@@ -1512,56 +1512,6 @@
     return filter (function(x) { return !(pred (x)); }, filterable);
   }
 
-  //# takeWhile :: Filterable f => (a -> Boolean, f a) -> f a
-  //.
-  //. Discards the first element which does not satisfy the predicate, and all
-  //. subsequent elements.
-  //.
-  //. This function is derived from [`filter`](#filter).
-  //.
-  //. See also [`dropWhile`](#dropWhile).
-  //.
-  //. ```javascript
-  //. > takeWhile (s => /x/.test (s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
-  //. ['xy', 'xz', 'yx']
-  //.
-  //. > takeWhile (s => /y/.test (s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
-  //. ['xy']
-  //.
-  //. > takeWhile (s => /z/.test (s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
-  //. []
-  //. ```
-  function takeWhile(pred, filterable) {
-    var take = true;
-    return filter (function(x) { return take = take && pred (x); },
-                   filterable);
-  }
-
-  //# dropWhile :: Filterable f => (a -> Boolean, f a) -> f a
-  //.
-  //. Retains the first element which does not satisfy the predicate, and all
-  //. subsequent elements.
-  //.
-  //. This function is derived from [`filter`](#filter).
-  //.
-  //. See also [`takeWhile`](#takeWhile).
-  //.
-  //. ```javascript
-  //. > dropWhile (s => /x/.test (s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
-  //. ['yz', 'zx', 'zy']
-  //.
-  //. > dropWhile (s => /y/.test (s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
-  //. ['xz', 'yx', 'yz', 'zx', 'zy']
-  //.
-  //. > dropWhile (s => /z/.test (s), ['xy', 'xz', 'yx', 'yz', 'zx', 'zy'])
-  //. ['xy', 'xz', 'yx', 'yz', 'zx', 'zy']
-  //. ```
-  function dropWhile(pred, filterable) {
-    var take = false;
-    return filter (function(x) { return take = take || !(pred (x)); },
-                   filterable);
-  }
-
   //# map :: Functor f => (a -> b, f a) -> f b
   //.
   //. Function wrapper for [`fantasy-land/map`][].
@@ -2380,8 +2330,6 @@
     reverse: reverse,
     sort: sort,
     sortBy: sortBy,
-    takeWhile: takeWhile,
-    dropWhile: dropWhile,
     traverse: traverse,
     sequence: sequence,
     extend: extend,

--- a/test/index.js
+++ b/test/index.js
@@ -943,42 +943,6 @@ test ('reject', function() {
   eq (Z.reject (odd, Just (1)), Nothing);
 });
 
-test ('takeWhile', function() {
-  eq (Z.takeWhile.length, 2);
-  eq (Z.takeWhile.name, 'takeWhile');
-
-  eq (Z.takeWhile (odd, []), []);
-  eq (Z.takeWhile (odd, [1]), [1]);
-  eq (Z.takeWhile (odd, [1, 3]), [1, 3]);
-  eq (Z.takeWhile (odd, [1, 3, 6]), [1, 3]);
-  eq (Z.takeWhile (odd, [1, 3, 6, 10]), [1, 3]);
-  eq (Z.takeWhile (odd, [1, 3, 6, 10, 15]), [1, 3]);
-  eq (Z.takeWhile (odd, Nil), Nil);
-  eq (Z.takeWhile (odd, Cons (1, Nil)), Cons (1, Nil));
-  eq (Z.takeWhile (odd, Cons (1, Cons (3, Nil))), Cons (1, Cons (3, Nil)));
-  eq (Z.takeWhile (odd, Cons (1, Cons (3, Cons (6, Nil)))), Cons (1, Cons (3, Nil)));
-  eq (Z.takeWhile (odd, Cons (1, Cons (3, Cons (6, Cons (10, Nil))))), Cons (1, Cons (3, Nil)));
-  eq (Z.takeWhile (odd, Cons (1, Cons (3, Cons (6, Cons (10, Cons (15, Nil)))))), Cons (1, Cons (3, Nil)));
-});
-
-test ('dropWhile', function() {
-  eq (Z.dropWhile.length, 2);
-  eq (Z.dropWhile.name, 'dropWhile');
-
-  eq (Z.dropWhile (odd, []), []);
-  eq (Z.dropWhile (odd, [1]), []);
-  eq (Z.dropWhile (odd, [1, 3]), []);
-  eq (Z.dropWhile (odd, [1, 3, 6]), [6]);
-  eq (Z.dropWhile (odd, [1, 3, 6, 10]), [6, 10]);
-  eq (Z.dropWhile (odd, [1, 3, 6, 10, 15]), [6, 10, 15]);
-  eq (Z.dropWhile (odd, Nil), Nil);
-  eq (Z.dropWhile (odd, Cons (1, Nil)), Nil);
-  eq (Z.dropWhile (odd, Cons (1, Cons (3, Nil))), Nil);
-  eq (Z.dropWhile (odd, Cons (1, Cons (3, Cons (6, Nil)))), Cons (6, Nil));
-  eq (Z.dropWhile (odd, Cons (1, Cons (3, Cons (6, Cons (10, Nil))))), Cons (6, Cons (10, Nil)));
-  eq (Z.dropWhile (odd, Cons (1, Cons (3, Cons (6, Cons (10, Cons (15, Nil)))))), Cons (6, Cons (10, Cons (15, Nil))));
-});
-
 test ('map', function() {
   eq (Z.map.length, 2);
   eq (Z.map.name, 'map');


### PR DESCRIPTION
These functions are unsound, as explained in #122. Given that it may take us a long time to reformulate these functions, I propose the following actions:

1.  Remove `Z.takeWhile` and `Z.dropWhile`.
2.  Release `sanctuary-type-classes@11.0.0`.
3.  Specialize `S.takeWhile` and `S.dropWhile` to `(a -> Boolean) -> Array a -> Array a`.
4.  Release `sanctuary@2.0.0`.
5.  Take as much time as necessary to resolve #122 satisfactorily.

There will be one breaking change to each project; this two-phase approach is no more disruptive than merging #122 immediately would have been.
