### PR TITLE
sanctuary-type-identifiers@3.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "types"
   ],
   "dependencies": {
-    "sanctuary-type-identifiers": "2.0.1"
+    "sanctuary-type-identifiers": "3.0.0"
   },
   "ignore": [
     "/.circleci/",

--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@
     };
   }
 
-  TypeClass['@@type'] = 'sanctuary-type-classes/TypeClass@1';
+  TypeClass.prototype['@@type'] = 'sanctuary-type-classes/TypeClass@1';
 
   //  data Location = Constructor | Value
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "npm run lint && sanctuary-test && npm run doctest"
   },
   "dependencies": {
-    "sanctuary-type-identifiers": "2.0.1"
+    "sanctuary-type-identifiers": "3.0.0"
   },
   "devDependencies": {
     "fantasy-land": "4.0.1",

--- a/test/Lazy.js
+++ b/test/Lazy.js
@@ -11,11 +11,11 @@ function Lazy(f) {
   this.run = f;
 }
 
-Lazy['@@type'] = 'sanctuary-type-classes/Lazy@1';
-
 Lazy[FL.of] = function(a) {
   return Lazy (function() { return a; });
 };
+
+Lazy.prototype['@@type'] = 'sanctuary-type-classes/Lazy@1';
 
 Lazy.prototype[FL.map] = function(f) {
   return Z.ap (Z.of (Lazy, f), this);

--- a/test/List.js
+++ b/test/List.js
@@ -22,8 +22,6 @@ function _List(tag, head, tail) {
   }
 }
 
-List['@@type'] = 'sanctuary-type-classes/List@1';
-
 //  Nil :: List a
 var Nil = List.Nil = new _List ('Nil');
 
@@ -38,6 +36,8 @@ List[FL.empty] = function() { return Nil; };
 List[FL.of] = function(x) { return Cons (x, Nil); };
 
 List[FL.zero] = List[FL.empty];
+
+List.prototype['@@type'] = 'sanctuary-type-classes/List@1';
 
 List.prototype[FL.equals] = function(other) {
   return this.isNil ?

--- a/test/Sum.js
+++ b/test/Sum.js
@@ -12,9 +12,9 @@ function Sum(value) {
   this.value = value;
 }
 
-Sum['@@type'] = 'sanctuary-type-classes/Sum@1';
-
 Sum[FL.empty] = function() { return Sum (0); };
+
+Sum.prototype['@@type'] = 'sanctuary-type-classes/Sum@1';
 
 Sum.prototype[FL.equals] = function(other) {
   return Z.equals (this.value, other.value);

--- a/test/index.js
+++ b/test/index.js
@@ -319,7 +319,7 @@ test ('Setoid', function() {
   eq (Z.Setoid.test (''), true);
   eq (Z.Setoid.test ([]), true);
   eq (Z.Setoid.test ({}), true);
-  eq (Z.Setoid.test ({'@@type': 'my-package/Quux@1'}), true);
+  eq (Z.Setoid.test ({'@@type': 'my-package/Quux@1'}), false);
 });
 
 test ('Ord', function() {
@@ -668,8 +668,9 @@ test ('equals', function() {
   eq (Z.equals (Math.sin, Math.cos), false);
   eq (Z.equals (Identity (Identity (Identity (0))), Identity (Identity (Identity (0)))), true);
   eq (Z.equals (Identity (Identity (Identity (0))), Identity (Identity (Identity (1)))), false);
-  eq (Z.equals ({'@@type': 'my-package/Quux@1'}, {'@@type': 'my-package/Quux@1'}), true);
+  eq (Z.equals ({'@@type': 'my-package/Quux@1'}, {'@@type': 'my-package/Quux@1'}), false);
   eq (Z.equals (Array.prototype, Array.prototype), true);
+  delete Maybe['@@type'];
   eq (Z.equals (Nothing.constructor, Maybe), true);
   eq (Z.equals ((Just (0)).constructor, Maybe), true);
   eq (Z.equals (Lazy$of (0), Lazy$of (0)), false);


### PR DESCRIPTION
<https://github.com/sanctuary-js/sanctuary-type-identifiers/releases/tag/v3.0.0>

We wish to update and release sanctuary-type-classes before updating the various ADT packages, because they depend on this package. As a result, this project's test suite will temporarily rely on the fact that `Object#fantasy-land/equals` happens to correctly determine equality of `Identity a`, `Maybe a`, and `Pair a b` values.
