### PR TITLE
derive ‘intercalate’ from ‘concat’, ‘empty’, and ‘reduce’

### DIFF
--- a/index.js
+++ b/index.js
@@ -2036,6 +2036,47 @@
     return any (function(y) { return equals (x, y); }, foldable);
   }
 
+  //# intercalate :: (Monoid m, Foldable f) => (m, f m) -> m
+  //.
+  //. Concatenates the elements of the given structure, separating each pair
+  //. of adjacent elements with the given separator.
+  //.
+  //. This function is derived from [`concat`](#concat), [`empty`](#empty),
+  //. and [`reduce`](#reduce).
+  //.
+  //. ```javascript
+  //. > intercalate (', ', [])
+  //. ''
+  //.
+  //. > intercalate (', ', ['foo', 'bar', 'baz'])
+  //. 'foo, bar, baz'
+  //.
+  //. > intercalate (', ', Nil)
+  //. ''
+  //.
+  //. > intercalate (', ', Cons ('foo', Cons ('bar', Cons ('baz', Nil))))
+  //. 'foo, bar, baz'
+  //.
+  //. > intercalate ([0, 0, 0], [])
+  //. []
+  //.
+  //. > intercalate ([0, 0, 0], [[1], [2, 3], [4, 5, 6], [7, 8], [9]])
+  //. [1, 0, 0, 0, 2, 3, 0, 0, 0, 4, 5, 6, 0, 0, 0, 7, 8, 0, 0, 0, 9]
+  //. ```
+  function intercalate(separator, foldable) {
+    var result = reduce (
+      function(acc, x) {
+        return {
+          empty: false,
+          value: concat (acc.value, acc.empty ? x : concat (separator, x))
+        };
+      },
+      {empty: true, value: empty (separator.constructor)},
+      foldable
+    );
+    return result.value;
+  }
+
   //# foldMap :: (Monoid m, Foldable f) => (TypeRep m, a -> m, f a) -> m
   //.
   //. Deconstructs a foldable by mapping every element to a monoid and
@@ -2326,6 +2367,7 @@
     any: any,
     none: none,
     elem: elem,
+    intercalate: intercalate,
     foldMap: foldMap,
     reverse: reverse,
     sort: sort,

--- a/test/index.js
+++ b/test/index.js
@@ -1296,6 +1296,24 @@ test ('elem', function() {
   eq (Z.elem (0, Nothing), false);
 });
 
+test ('intercalate', function() {
+  eq (Z.intercalate.length, 2);
+  eq (Z.intercalate.name, 'intercalate');
+
+  eq (Z.intercalate (', ', []), '');
+  eq (Z.intercalate (', ', ['foo']), 'foo');
+  eq (Z.intercalate (', ', ['foo', 'bar']), 'foo, bar');
+  eq (Z.intercalate (', ', ['foo', 'bar', 'baz']), 'foo, bar, baz');
+  eq (Z.intercalate ([0, 0, 0], []), []);
+  eq (Z.intercalate ([0, 0, 0], [[1]]), [1]);
+  eq (Z.intercalate ([0, 0, 0], [[1], [2]]), [1, 0, 0, 0, 2]);
+  eq (Z.intercalate ([0, 0, 0], [[1], [2], [3]]), [1, 0, 0, 0, 2, 0, 0, 0, 3]);
+  eq (Z.intercalate ('.', Nil), '');
+  eq (Z.intercalate ('.', Cons ('x', Nil)), 'x');
+  eq (Z.intercalate ('.', Cons ('x', Cons ('y', Nil))), 'x.y');
+  eq (Z.intercalate ('.', Cons ('x', Cons ('y', Cons ('z', Nil)))), 'x.y.z');
+});
+
 test ('foldMap', function() {
   eq (Z.foldMap.length, 3);
   eq (Z.foldMap.name, 'foldMap');


### PR DESCRIPTION
@syaiful6 first proposed this function in March 2017 (sanctuary-js/sanctuary#360). @masaeedu opened a pull request to add the function in June 2018 (sanctuary-js/sanctuary#569). Let's finally define `intercalate` in January 2020. :)
