### PR TITLE
remove Function.name polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -254,15 +254,6 @@
     return _funcPath (false, path, implementations);
   }
 
-  //  functionName :: Function -> String
-  var functionName = has ('name', function f() {}) ?
-    function functionName(f) { return f.name; } :
-    /* istanbul ignore next */
-    function functionName(f) {
-      var match = /function (\w*)/.exec (f);
-      return match == null ? '' : match[1];
-    };
-
   //  $ :: (String, Array TypeClass, StrMap (Array Location)) -> TypeClass
   function $(_name, dependencies, requirements) {
     function getBoundMethod(_name) {
@@ -271,7 +262,7 @@
         function(typeRep) {
           var f = funcPath ([name], typeRep);
           return f == null && typeof typeRep === 'function' ?
-            implPath ([functionName (typeRep), name]) :
+            implPath ([typeRep.name, name]) :
             f;
         } :
         function(x) {


### PR DESCRIPTION
[`Function.name`][1] has been widely supported for years at this point, so the polyfill no longer seems necessary.


[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name
