### PR TITLE
Remove special treatment of non-compliant values in lte and equals

### DIFF
--- a/index.js
+++ b/index.js
@@ -1111,10 +1111,11 @@
     }
   };
 
-  //# equals :: (a, b) -> Boolean
+  //# equals :: Setoid a => (a, a) -> Boolean
   //.
   //. Returns `true` if its arguments are of the same type and equal according
-  //. to the type's [`fantasy-land/equals`][] method; `false` otherwise.
+  //. to the type's [`fantasy-land/equals`][] method. Returns `false` for
+  //. inputs of differing types.
   //.
   //. `fantasy-land/equals` implementations are provided for the following
   //. built-in types: Null, Undefined, Boolean, Number, Date, RegExp, String,
@@ -1154,20 +1155,18 @@
 
       $pairs.push ([x, y]);
       try {
-        return Z.Setoid.test (x) &&
-               Z.Setoid.test (y) &&
-               Z.Setoid.methods.equals (x) (y);
+        return Z.Setoid.methods.equals (x) (y);
       } finally {
         $pairs.pop ();
       }
     };
   }
 
-  //# lt :: (a, b) -> Boolean
+  //# lt :: Ord a => (a, a) -> Boolean
   //.
   //. Returns `true` if its arguments are of the same type and the first is
   //. less than the second according to the type's [`fantasy-land/lte`][]
-  //. method; `false` otherwise.
+  //. method. Returns `false` for inputs of differing types.
   //.
   //. This function is derived from [`lte`](#lte).
   //.
@@ -1185,11 +1184,12 @@
   //. ```
   Z.lt = (x, y) => sameType (x, y) && !(Z.lte (y, x));
 
-  //# lte :: (a, b) -> Boolean
+  //# lte :: Ord a => (a, a) -> Boolean
   //.
   //. Returns `true` if its arguments are of the same type and the first
   //. is less than or equal to the second according to the type's
-  //. [`fantasy-land/lte`][] method; `false` otherwise.
+  //. [`fantasy-land/lte`][] method. Returns `false` for inputs of
+  //. differing types.
   //.
   //. `fantasy-land/lte` implementations are provided for the following
   //. built-in types: Null, Undefined, Boolean, Number, Date, String, Array,
@@ -1225,18 +1225,18 @@
 
       $pairs.push ([x, y]);
       try {
-        return Z.Ord.test (x) && Z.Ord.test (y) && Z.Ord.methods.lte (x) (y);
+        return Z.Ord.methods.lte (x) (y);
       } finally {
         $pairs.pop ();
       }
     };
   }
 
-  //# gt :: (a, b) -> Boolean
+  //# gt :: Ord a => (a, a) -> Boolean
   //.
   //. Returns `true` if its arguments are of the same type and the first is
   //. greater than the second according to the type's [`fantasy-land/lte`][]
-  //. method; `false` otherwise.
+  //. method. Returns `false` for inputs of differing types.
   //.
   //. This function is derived from [`lte`](#lte).
   //.
@@ -1254,11 +1254,12 @@
   //. ```
   Z.gt = (x, y) => Z.lt (y, x);
 
-  //# gte :: (a, b) -> Boolean
+  //# gte :: Ord a => (a, a) -> Boolean
   //.
   //. Returns `true` if its arguments are of the same type and the first
   //. is greater than or equal to the second according to the type's
-  //. [`fantasy-land/lte`][] method; `false` otherwise.
+  //. [`fantasy-land/lte`][] method. Returns `false` for inputs of
+  //. differing types.
   //.
   //. This function is derived from [`lte`](#lte).
   //.

--- a/test/index.js
+++ b/test/index.js
@@ -673,11 +673,9 @@ test ('equals', () => {
   eq (Z.equals (Math.sin, Math.cos), false);
   eq (Z.equals (Identity (Identity (Identity (0))), Identity (Identity (Identity (0)))), true);
   eq (Z.equals (Identity (Identity (Identity (0))), Identity (Identity (Identity (1)))), false);
-  eq (Z.equals (Useless, Useless), false);
   eq (Z.equals (Array.prototype, Array.prototype), true);
   eq (Z.equals (Nothing.constructor, Maybe), true);
   eq (Z.equals ((Just (0)).constructor, Maybe), true);
-  eq (Z.equals (Lazy$of (0), Lazy$of (0)), false);
 
   const $0 = {z: 0};
   const $1 = {z: 1};
@@ -798,7 +796,6 @@ test ('lte', () => {
   eq (Z.lte (Identity (Identity (Identity (0))), Identity (Identity (Identity (0)))), true);
   eq (Z.lte (Identity (Identity (Identity (0))), Identity (Identity (Identity (1)))), true);
   eq (Z.lte (Identity (Identity (Identity (1))), Identity (Identity (Identity (0)))), false);
-  eq (Z.lte (Lazy$of (0), Lazy$of (0)), false);
   eq (Z.lte ('abc', 123), false);
 
   const $0 = {z: 0};


### PR DESCRIPTION
This PR competes with and so closes #154

Instead of arbitrarily returning false, these functions now throw when
given invalid (without the proper type class) input.