### PR TITLE
Principled Setoid and Ord with improved performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -1245,22 +1245,14 @@
     },
   }]);
 
-  //# equals :: (a, b) -> Boolean
+  //# equals :: Setoid a => (a, a) -> Boolean
   //.
   //. Returns `true` if its arguments are equal; `false` otherwise.
   //.
-  //. Specifically:
-  //.
-  //.   - Arguments with different [type identities][] are unequal.
-  //.
-  //.   - If the first argument has a [`fantasy-land/equals`][] method,
-  //.     that method is invoked to determine whether the arguments are
-  //.     equal (`fantasy-land/equals` implementations are provided for the
-  //.     following built-in types: Null, Undefined, Boolean, Number, Date,
-  //.     RegExp, String, Array, Arguments, Error, Object, and Function).
-  //.
-  //.   - Otherwise, the arguments are equal if their
-  //.     [entries][`Object.entries`] are equal (according to this algorithm).
+  //. > [!IMPORTANT]
+  //. >
+  //. > Arguments must be Setoids of the same type; providing arguments of
+  //. > differing types, or non-Setoid arguments, has undefined behaviour.
   //.
   //. The algorithm supports circular data structures. Two arrays are equal
   //. if they have the same index paths and for each path have equal values.
@@ -1286,8 +1278,6 @@
     const $pairs = [];
 
     Z.equals = (x, y) => {
-      if (!(sameType (x, y))) return false;
-
       //  This algorithm for comparing circular data structures was
       //  suggested in <http://stackoverflow.com/a/40622794/312785>.
       if ($pairs.some (([xx, yy]) => xx === x && yy === y)) {
@@ -1296,9 +1286,7 @@
 
       $pairs.push ([x, y]);
       try {
-        return Z.Setoid.test (x) ?
-               Z.Setoid.methods.equals (y, x) :
-               Object$prototype$equals.call (x, y);
+        return Z.Setoid.methods.equals (y, x);
       } finally {
         $pairs.pop ();
       }
@@ -2385,7 +2373,6 @@
 //. [Semigroupoid]:             v:fantasyland/fantasy-land#semigroupoid
 //. [Setoid]:                   v:fantasyland/fantasy-land#setoid
 //. [Traversable]:              v:fantasyland/fantasy-land#traversable
-//. [`Object.entries`]:         https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
 //. [`fantasy-land/alt`]:       v:fantasyland/fantasy-land#alt-method
 //. [`fantasy-land/ap`]:        v:fantasyland/fantasy-land#ap-method
 //. [`fantasy-land/bimap`]:     v:fantasyland/fantasy-land#bimap-method
@@ -2395,7 +2382,6 @@
 //. [`fantasy-land/concat`]:    v:fantasyland/fantasy-land#concat-method
 //. [`fantasy-land/contramap`]: v:fantasyland/fantasy-land#contramap-method
 //. [`fantasy-land/empty`]:     v:fantasyland/fantasy-land#empty-method
-//. [`fantasy-land/equals`]:    v:fantasyland/fantasy-land#equals-method
 //. [`fantasy-land/extend`]:    v:fantasyland/fantasy-land#extend-method
 //. [`fantasy-land/extract`]:   v:fantasyland/fantasy-land#extract-method
 //. [`fantasy-land/filter`]:    v:fantasyland/fantasy-land#filter-method
@@ -2409,5 +2395,4 @@
 //. [`fantasy-land/traverse`]:  v:fantasyland/fantasy-land#traverse-method
 //. [`fantasy-land/zero`]:      v:fantasyland/fantasy-land#zero-method
 //. [stable sort]:              https://en.wikipedia.org/wiki/Sorting_algorithm#Stability
-//. [type identities]:          v:sanctuary-js/sanctuary-type-identifiers
 //. [type-classes]:             https://github.com/sanctuary-js/sanctuary-def#type-classes

--- a/index.js
+++ b/index.js
@@ -112,9 +112,6 @@
   //  pair :: a -> b -> Array2 a b
   const pair = x => y => [x, y];
 
-  //  sameType :: (a, b) -> Boolean
-  const sameType = (x, y) => typeof x === typeof y && type (x) === type (y);
-
   //  sortedKeys :: Object -> Array String
   const sortedKeys = o => (Object.keys (o)).sort ();
 
@@ -1293,7 +1290,7 @@
     };
   }
 
-  //# lt :: (a, b) -> Boolean
+  //# lt :: Ord a => (a, a) -> Boolean
   //.
   //. Returns `true` if its arguments are of the same type and the first is
   //. less than the second according to the type's [`fantasy-land/lte`][]
@@ -1313,9 +1310,9 @@
   //. > Z.lt (1, 0)
   //. false
   //. ```
-  Z.lt = (x, y) => sameType (x, y) && !(Z.lte (y, x));
+  Z.lt = (x, y) => !(Z.lte (y, x));
 
-  //# lte :: (a, b) -> Boolean
+  //# lte :: Ord a => (a, a) -> Boolean
   //.
   //. Returns `true` if its arguments are of the same type and the first
   //. is less than or equal to the second according to the type's
@@ -1345,8 +1342,6 @@
     const $pairs = [];
 
     Z.lte = (x, y) => {
-      if (!(sameType (x, y))) return false;
-
       //  This algorithm for comparing circular data structures was
       //  suggested in <http://stackoverflow.com/a/40622794/312785>.
       if ($pairs.some (([xx, yy]) => xx === x && yy === y)) {
@@ -1355,14 +1350,14 @@
 
       $pairs.push ([x, y]);
       try {
-        return Z.Ord.test (x) && Z.Ord.methods.lte (y, x);
+        return Z.Ord.methods.lte (y, x);
       } finally {
         $pairs.pop ();
       }
     };
   }
 
-  //# gt :: (a, b) -> Boolean
+  //# gt :: Ord a => (a, a) -> Boolean
   //.
   //. Returns `true` if its arguments are of the same type and the first is
   //. greater than the second according to the type's [`fantasy-land/lte`][]
@@ -1384,7 +1379,7 @@
   //. ```
   Z.gt = (x, y) => Z.lt (y, x);
 
-  //# gte :: (a, b) -> Boolean
+  //# gte :: Ord a => (a, a) -> Boolean
   //.
   //. Returns `true` if its arguments are of the same type and the first
   //. is greater than or equal to the second according to the type's

--- a/test/index.js
+++ b/test/index.js
@@ -345,6 +345,7 @@ test ('Setoid', () => {
   eq (Z.Setoid.test (''), true);
   eq (Z.Setoid.test ([]), true);
   eq (Z.Setoid.test ({}), true);
+  eq (Z.Setoid.test (ones), true);
   eq (Z.Setoid.test (Useless), false);
   eq (Z.Setoid.test ([Useless]), false);
   eq (Z.Setoid.test ({foo: Useless}), false);
@@ -358,6 +359,7 @@ test ('Ord', () => {
   eq (Z.Ord.test (''), true);
   eq (Z.Ord.test ([]), true);
   eq (Z.Ord.test ({}), true);
+  eq (Z.Ord.test (ones), true);
   eq (Z.Ord.test (Math.abs), false);
   eq (Z.Ord.test ([Math.abs]), false);
   eq (Z.Ord.test ({foo: Math.abs}), false);
@@ -732,15 +734,12 @@ test ('lt', () => {
   eq (Z.lt (0, 0), false);
   eq (Z.lt (0, 1), true);
   eq (Z.lt (1, 0), false);
-  eq (Z.lt ('abc', 123), false);
 });
 
 test ('lte', () => {
   eq (Z.lte.length, 2);
 
   eq (Z.lte (null, null), true);
-  eq (Z.lte (null, undefined), false);
-  eq (Z.lte (undefined, null), false);
   eq (Z.lte (undefined, undefined), true);
   eq (Z.lte (false, false), true);
   eq (Z.lte (false, true), true);
@@ -750,10 +749,6 @@ test ('lte', () => {
   eq (Z.lte (new Boolean (false), new Boolean (true)), true);
   eq (Z.lte (new Boolean (true), new Boolean (false)), false);
   eq (Z.lte (new Boolean (true), new Boolean (true)), true);
-  eq (Z.lte (false, new Boolean (false)), false);
-  eq (Z.lte (new Boolean (false), false), false);
-  eq (Z.lte (true, new Boolean (true)), false);
-  eq (Z.lte (new Boolean (true), true), false);
   eq (Z.lte (42, 42), true);
   eq (Z.lte (42, 43), true);
   eq (Z.lte (43, 42), false);
@@ -779,8 +774,6 @@ test ('lte', () => {
   eq (Z.lte (new Number (-Infinity), new Number (-Infinity)), true);
   eq (Z.lte (new Number (NaN), new Number (Math.PI)), true);
   eq (Z.lte (new Number (Math.PI), new Number (NaN)), false);
-  eq (Z.lte (42, new Number (42)), false);
-  eq (Z.lte (new Number (42), 42), false);
   eq (Z.lte (new Date (0), new Date (0)), true);
   eq (Z.lte (new Date (0), new Date (1)), true);
   eq (Z.lte (new Date (1), new Date (0)), false);
@@ -792,8 +785,6 @@ test ('lte', () => {
   eq (Z.lte (new String (''), new String ('')), true);
   eq (Z.lte (new String ('abc'), new String ('abc')), true);
   eq (Z.lte (new String ('abc'), new String ('xyz')), true);
-  eq (Z.lte ('abc', new String ('abc')), false);
-  eq (Z.lte (new String ('abc'), 'abc'), false);
   eq (Z.lte ([], []), true);
   eq (Z.lte ([1, 2], [1, 2]), true);
   eq (Z.lte ([1, 2, 3], [1, 2]), false);
@@ -832,7 +823,6 @@ test ('lte', () => {
   eq (Z.lte (Identity (Identity (Identity (0))), Identity (Identity (Identity (0)))), true);
   eq (Z.lte (Identity (Identity (Identity (0))), Identity (Identity (Identity (1)))), true);
   eq (Z.lte (Identity (Identity (Identity (1))), Identity (Identity (Identity (0)))), false);
-  eq (Z.lte (Lazy$of (0), Lazy$of (0)), false);
   eq (Z.lte ('abc', 123), false);
 
   eq (Z.lte (alienValues.Array, domesticValues.Array), true);
@@ -856,7 +846,6 @@ test ('gt', () => {
   eq (Z.gt (0, 0), false);
   eq (Z.gt (0, 1), false);
   eq (Z.gt (1, 0), true);
-  eq (Z.gt ('abc', 123), false);
 });
 
 test ('gte', () => {
@@ -865,7 +854,6 @@ test ('gte', () => {
   eq (Z.gte (0, 0), true);
   eq (Z.gte (0, 1), false);
   eq (Z.gte (1, 0), true);
-  eq (Z.gte ('abc', 123), false);
 });
 
 test ('min', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -595,11 +595,6 @@ test ('equals', () => {
     builtinSetoidArb: jsc.record ({
       value: tie ('nestedSetoidArb'),
     }),
-    noSetoidArb: jsc.record ({
-      'value': tie ('nestedSetoidArb'),
-      '@@type': jsc.constant ('sanctuary-type-classes/NoSetoid@1'),
-      '@@show': jsc.constant (function() { return `NoSetoid (${show (this.value)})`; }),
-    }),
     customSetoidArb: jsc.record ({
       'value': tie ('nestedSetoidArb'),
       '@@type': jsc.constant ('sanctuary-type-classes/CustomSetoid@1'),
@@ -610,7 +605,6 @@ test ('equals', () => {
     }),
     nestedSetoidArb: jsc.oneof ([
       tie ('builtinSetoidArb'),
-      tie ('noSetoidArb'),
       tie ('customSetoidArb'),
       jsc.nat,
     ]),
@@ -621,8 +615,6 @@ test ('equals', () => {
   eq (Z.equals.length, 2);
 
   eq (Z.equals (null, null), true);
-  eq (Z.equals (null, undefined), false);
-  eq (Z.equals (undefined, null), false);
   eq (Z.equals (undefined, undefined), true);
   eq (Z.equals (false, false), true);
   eq (Z.equals (false, true), false);
@@ -632,10 +624,6 @@ test ('equals', () => {
   eq (Z.equals (new Boolean (false), new Boolean (true)), false);
   eq (Z.equals (new Boolean (true), new Boolean (false)), false);
   eq (Z.equals (new Boolean (true), new Boolean (true)), true);
-  eq (Z.equals (false, new Boolean (false)), false);
-  eq (Z.equals (new Boolean (false), false), false);
-  eq (Z.equals (true, new Boolean (true)), false);
-  eq (Z.equals (new Boolean (true), true), false);
   eq (Z.equals (0, 0), true);
   eq (Z.equals (0, -0), true);
   eq (Z.equals (-0, 0), true);
@@ -645,8 +633,6 @@ test ('equals', () => {
   eq (Z.equals (Infinity, -Infinity), false);
   eq (Z.equals (-Infinity, Infinity), false);
   eq (Z.equals (-Infinity, -Infinity), true);
-  eq (Z.equals (NaN, Math.PI), false);
-  eq (Z.equals (Math.PI, NaN), false);
   eq (Z.equals (new Number (0), new Number (0)), true);
   eq (Z.equals (new Number (0), new Number (-0)), true);
   eq (Z.equals (new Number (-0), new Number (0)), true);
@@ -658,10 +644,6 @@ test ('equals', () => {
   eq (Z.equals (new Number (-Infinity), new Number (-Infinity)), true);
   eq (Z.equals (new Number (NaN), new Number (Math.PI)), false);
   eq (Z.equals (new Number (Math.PI), new Number (NaN)), false);
-  eq (Z.equals (42, new Number (42)), false);
-  eq (Z.equals (new Number (42), 42), false);
-  eq (Z.equals (NaN, new Number (NaN)), false);
-  eq (Z.equals (new Number (NaN), NaN), false);
   eq (Z.equals (new Date (0), new Date (0)), true);
   eq (Z.equals (new Date (0), new Date (1)), false);
   eq (Z.equals (new Date (1), new Date (0)), false);
@@ -681,8 +663,6 @@ test ('equals', () => {
   eq (Z.equals (new String (''), new String ('')), true);
   eq (Z.equals (new String ('abc'), new String ('abc')), true);
   eq (Z.equals (new String ('abc'), new String ('xyz')), false);
-  eq (Z.equals ('abc', new String ('abc')), false);
-  eq (Z.equals (new String ('abc'), 'abc'), false);
   eq (Z.equals ([], []), true);
   eq (Z.equals ([1, 2], [1, 2]), true);
   eq (Z.equals ([1, 2, 3], [1, 2]), false);
@@ -724,11 +704,9 @@ test ('equals', () => {
   eq (Z.equals (Math.sin, Math.cos), false);
   eq (Z.equals (Identity (Identity (Identity (0))), Identity (Identity (Identity (0)))), true);
   eq (Z.equals (Identity (Identity (Identity (0))), Identity (Identity (Identity (1)))), false);
-  eq (Z.equals (Useless, Useless), true);
   eq (Z.equals (Array.prototype, Array.prototype), true);
   eq (Z.equals (Nothing.constructor, Maybe), true);
   eq (Z.equals ((Just (0)).constructor, Maybe), true);
-  eq (Z.equals (Lazy$of (0), Lazy$of (0)), false);
 
   eq (Z.equals (alienValues.Array, domesticValues.Array), true);
   eq (Z.equals (alienValues.Boolean, domesticValues.Boolean), true);
@@ -823,8 +801,6 @@ test ('lte', () => {
   eq (Z.lte ([1, 2], [2]), true);
   eq (Z.lte ([], [undefined]), true);
   eq (Z.lte ([undefined], []), false);
-  eq (Z.lte ([1], [undefined]), false);
-  eq (Z.lte ([undefined], [1]), false);
   eq (Z.lte ([0], [-0]), true);
   eq (Z.lte ([NaN], [NaN]), true);
   eq (Z.lte (ones, ones), true);
@@ -846,8 +822,6 @@ test ('lte', () => {
   eq (Z.lte ({x: 1, y: 2}, {y: 2, x: 1}), true);
   eq (Z.lte ({x: 1, y: 2, z: 3}, {x: 1, y: 2}), false);
   eq (Z.lte ({x: 1, y: 2}, {x: 1, y: 2, z: 3}), true);
-  eq (Z.lte ({x: 1, y: 2, z: 3}, {x: 1, y: 2, z: undefined}), false);
-  eq (Z.lte ({x: 1, y: 2, z: undefined}, {x: 1, y: 2, z: 3}), false);
   eq (Z.lte ({x: 1, y: 1}, {x: 2, y: 1}), true);
   eq (Z.lte ({x: 2, y: 1}, {x: 1, y: 2}), false);
   eq (Z.lte ({x: 0, y: 0}, {x: 1}), true);


### PR DESCRIPTION
Opened a draft PR for discussion.
See https://github.com/sanctuary-js/sanctuary-type-classes/pull/151#discussion_r692184710.

Remember we did that thing where we made `Z.equals` more useful by having it fall back to structural equality for garbage inputs (#154)? We ended up with a useful, but unprincipled and slow, equality function. That's fine and all, but I don't like that:

- Sanctuary is now forced to use this slow function, despite already having ensured that inputs are Setoids of the same type.
- Many Setoid implementations build on `Z.equals`, making them slow for no reason.
- Some Ord implementations, and `Z.lte` itself, builds on Z.equals.