### PR TITLE
Switch from Array to WeakSet for detecting circular structures

### DIFF
--- a/index.js
+++ b/index.js
@@ -681,9 +681,9 @@
       `https://github.com/sanctuary-js/sanctuary-type-classes/tree/v${version}#${_name}`,
       dependencies,
       ($seen => x => {
-        if ($seen.includes (x)) return true;
+        if ($seen.has (x)) return true;
 
-        $seen.push (x);
+        $seen.add (x);
         try {
           return (
             staticMethods.every (({name, implementations}) => (
@@ -695,9 +695,9 @@
             ))
           );
         } finally {
-          $seen.pop ();
+          $seen.delete (x);
         }
-      }) ([])
+      }) (new WeakSet ())
     );
 
     typeClass.methods = {};


### PR DESCRIPTION
> [!WARNING]
>
> **Might not be worth merging!** See below.

We theorized that this would improve performance, assuming that [`WeakSet.prototype.add`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/add) and [`WeakSet.prototype.delete`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/delete) have constant time performance characteristics. What I measured was a drop in performance, however. Here's the relevant benchmark results:

```console
$ npm i --prefix bench "git+file://$(pwd)/#67662b7"
$ npm run bench -- --benchmark old-vs-new
```

After removing benchmarks that showed no significant change:

```txt
┌────────────────────────────────┬──────────────────────────────┬──────────────────────────────┬────────┬─────────┬───┐
│ suite                          │ old                          │ new                          │ diff   │ change  │ α │
├────────────────────────────────┼──────────────────────────────┼──────────────────────────────┼────────┼─────────┼───┤
│ test.Comonad.Identity.flat     │ 401,461 Hz ±0.27% (n 98)     │ 326,030 Hz ±0.44% (n 96)     │ 010.4% │ -018.8% │ ✗ │
├────────────────────────────────┼──────────────────────────────┼──────────────────────────────┼────────┼─────────┼───┤
│ test.Comonad.Identity.nested   │ 1,930,428 Hz ±0.19% (n 96)   │ 1,264,705 Hz ±0.72% (n 92)   │ 020.8% │ -034.5% │ ✗ │
├────────────────────────────────┼──────────────────────────────┼──────────────────────────────┼────────┼─────────┼───┤
│ test.Monoid.Identity.flat      │ 444,559 Hz ±1.43% (n 95)     │ 406,916 Hz ±0.90% (n 91)     │ 004.4% │ -008.5% │   │
├────────────────────────────────┼──────────────────────────────┼──────────────────────────────┼────────┼─────────┼───┤
│ test.Monoid.Identity.nested    │ 5,381,531 Hz ±0.25% (n 90)   │ 3,616,869 Hz ±0.19% (n 95)   │ 019.6% │ -032.8% │ ✗ │
├────────────────────────────────┼──────────────────────────────┼──────────────────────────────┼────────┼─────────┼───┤
│ test.Contravariant.Function    │ 4,497,084 Hz ±0.24% (n 96)   │ 3,415,016 Hz ±0.20% (n 97)   │ 013.7% │ -024.1% │ ✗ │
└────────────────────────────────┴──────────────────────────────┴──────────────────────────────┴────────┴─────────┴───┘
```
